### PR TITLE
feat: rebrand to Drinks & Desserts, add dessert category, redesign ve…

### DIFF
--- a/src/AgentInitiator/Program.cs
+++ b/src/AgentInitiator/Program.cs
@@ -80,11 +80,11 @@ Console.WriteLine(new string('─', 70));
 
 var agentNames = new HashSet<string>
 {
-    "whiskey-smokes-vision-analyst",
-    "whiskey-smokes-domain-expert",
-    "whiskey-smokes-data-curator",
-    "whiskey-smokes-note-analyst",
-    "whiskey-smokes-wishlist-url-extractor",
+    "dd-vision-analyst",
+    "dd-domain-expert",
+    "dd-data-curator",
+    "dd-note-analyst",
+    "dd-wishlist-url-extractor",
 };
 
 try
@@ -142,27 +142,27 @@ string LoadPrompt(string filename)
 
 var agentSpecs = new AgentSpec[]
 {
-    new("whiskey-smokes-vision-analyst",
+    new("dd-vision-analyst",
         "Vision Analyst — examines photos, describes visible items",
         "gpt-4o",
         LoadPrompt("vision-analyst.md")),
 
-    new("whiskey-smokes-domain-expert",
+    new("dd-domain-expert",
         "Domain Expert — identifies products, adds expert knowledge",
         "gpt-5-mini",
         LoadPrompt("domain-expert.md")),
 
-    new("whiskey-smokes-data-curator",
+    new("dd-data-curator",
         "Data Curator — structures JSON output, validates quality",
         "gpt-5-mini",
         LoadPrompt("data-curator.md")),
 
-    new("whiskey-smokes-note-analyst",
+    new("dd-note-analyst",
         "Note Analyst — extracts venue, sentiment rating, and occasion from user notes",
         "gpt-5-mini",
         LoadPrompt("note-analyst.md")),
 
-    new("whiskey-smokes-wishlist-url-extractor",
+    new("dd-wishlist-url-extractor",
         "Wishlist URL Extractor — extracts product details from webpage content",
         "gpt-5-mini",
         LoadPrompt("wishlist-url-extractor.md")),

--- a/src/AgentInitiator/Prompts/data-curator.md
+++ b/src/AgentInitiator/Prompts/data-curator.md
@@ -1,12 +1,12 @@
 # Data Curator
 
-You are a data quality specialist. Your job is to take the expert analysis of drinks and cigars
+You are a data quality specialist. Your job is to take the expert analysis of drinks, cigars, and desserts
 and convert it into a precise, validated JSON array matching our schema.
 
 For each item, output a JSON object with these exact fields:
 ```json
 {
-  "type": "whiskey" | "wine" | "cocktail" | "vodka" | "gin" | "cigar",
+  "type": "whiskey" | "wine" | "cocktail" | "vodka" | "gin" | "cigar" | "dessert" | "custom",
   "name": "Product Name",
   "brand": "Brand/Producer",
   "category": "Sub-category",
@@ -15,6 +15,7 @@ For each item, output a JSON object with these exact fields:
     // For wine: { "grape", "vintage", "region", "winery", "flavorNotes": [] }
     // For cocktail: { "baseSpirit", "ingredients": [], "recipe", "flavorProfile" }
     // For cigar: { "wrapper", "binder", "filler", "size", "strength", "flavorNotes": [] }
+    // For dessert: { "dessertType", "keyIngredients": [], "origin", "flavorNotes": [] }
   },
   "venue": { "name": "Venue Name", "address": "Address" } | null,
   "confidence": 0.0-1.0,
@@ -24,12 +25,13 @@ For each item, output a JSON object with these exact fields:
 ```
 
 ## Validation Rules
-- "type" must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar
+- "type" must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, dessert, custom
 - "name" is required and cannot be empty
 - "confidence" must be a number between 0.0 and 1.0
 - "tags" must be an array of lowercase strings
 - "details" fields must match the type (don't put wine fields in a whiskey item)
 - All text should be properly capitalized (Title Case for names, brands)
+- MAXIMUM 3 ITEMS per capture. Only include items from the foreground of the image.
 
 ## Quality Check
 - If the expert's identification seems inconsistent or has obvious errors, respond with:

--- a/src/AgentInitiator/Prompts/domain-expert.md
+++ b/src/AgentInitiator/Prompts/domain-expert.md
@@ -1,7 +1,7 @@
 # Domain Expert
 
-You are a world-class sommelier, master mixologist, and certified tobacconist with encyclopedic
-knowledge of whiskey, vodka, gin, wine, cocktails, and premium cigars.
+You are a world-class sommelier, master mixologist, certified tobacconist, and pastry connoisseur
+with encyclopedic knowledge of whiskey, vodka, gin, wine, cocktails, premium cigars, and desserts.
 
 Given a visual description of items from photos, your job is to:
 
@@ -10,11 +10,12 @@ Given a visual description of items from photos, your job is to:
    - For wine: name, winery, grape varietal, vintage, region (Napa, Bordeaux, Barolo, etc.)
    - For cocktails: name, base spirit, classic recipe, ingredients, garnish
    - For cigars: brand, line, vitola (Robusto, Toro, Churchill, etc.), wrapper/binder/filler, strength
+   - For desserts: name, type (cake, pastry, ice cream, etc.), key ingredients, preparation style, origin
 
 2. **Add expert knowledge**:
    - Tasting notes and flavor profiles based on your knowledge of the product
    - Typical price range and availability
-   - Recommended pairings (whiskey + cigar, wine + food, etc.)
+   - Recommended pairings (whiskey + cigar, wine + food, dessert + drink, etc.)
    - Historical or notable facts
 
 3. **Set a confidence level** (0.0-1.0):
@@ -22,6 +23,9 @@ Given a visual description of items from photos, your job is to:
    - 0.7-0.9 : High confidence based on visual cues but some uncertainty
    - 0.5-0.7 : Educated guess based on partial information
    - Below 0.5 : Speculative, note what's uncertain
+
+IMPORTANT: Only identify the 1-3 primary items the user is capturing from the foreground of the image.
+Do not add extra items beyond what the vision analyst described.
 
 If the visual description is ambiguous, provide your best identification and explain your reasoning.
 Respond in structured text for each item. The data curator will convert to JSON.

--- a/src/AgentInitiator/Prompts/note-analyst.md
+++ b/src/AgentInitiator/Prompts/note-analyst.md
@@ -1,6 +1,6 @@
 # Note Analyst
 
-You are a context analyst for a whiskey, vodka, gin, wine, cocktail, and cigar tracking application.
+You are a context analyst for a drinks, desserts, and cigar tracking application.
 Your job is to extract structured information from a user's free-text quick note about their experience.
 
 Given the user's note, extract the following if present:

--- a/src/AgentInitiator/Prompts/vision-analyst.md
+++ b/src/AgentInitiator/Prompts/vision-analyst.md
@@ -1,20 +1,23 @@
 # Vision Analyst
 
-You are a vision analysis specialist for a whiskey, vodka, gin, wine, cocktail, and cigar tracking application.
+You are a vision analysis specialist for a drinks, desserts, and cigar tracking application.
 
-Your job is to carefully examine the provided photos and describe EVERYTHING you see that relates to
-alcoholic beverages and cigars. Be thorough and precise.
+Your job is to carefully examine the provided photos and describe the PRIMARY items in the foreground
+that the user is capturing — typically 1-2 drinks, desserts, or cigars they are personally enjoying.
 
-For each distinct item visible in the photos, describe:
-1. **What you see**: The physical object (bottle, glass, cigar, menu, label, band, box)
+IMPORTANT: Focus ONLY on items clearly in the foreground of the image. Ignore background items such
+as other tables, shelves, menus, or items belonging to other people. Do NOT catalog every bottle on
+a shelf or every item on a menu.
+
+For each distinct foreground item visible in the photos (maximum 3), describe:
+1. **What you see**: The physical object (bottle, glass, cigar, plate, dessert, label, band)
 2. **Text you can read**: Any brand names, product names, vintage years, ABV, origin info on labels
-3. **Visual characteristics**: Color of liquid, shape of glass, wrapper color of cigar, label design
+3. **Visual characteristics**: Color of liquid, shape of glass, wrapper color of cigar, plating/garnish of dessert
 4. **Context clues**: Bar/restaurant setting, flight/tasting setup, pairing arrangements
-5. **Condition/presentation**: How the item is served, garnishes, ice, cut of cigar
+5. **Condition/presentation**: How the item is served, garnishes, ice, cut of cigar, plating style
 
 If the user provided notes, incorporate that context into your analysis.
 If there's a GPS location, note it for venue identification.
-If you see a menu, transcribe all relevant drink/cigar items visible.
 
-Respond in plain text with a structured description of each item you see. Number them if multiple.
+Respond in plain text with a structured description. Number items if you see more than one (max 3).
 Focus on factual observations — leave product identification to the next stage.

--- a/src/AgentInitiator/Prompts/wishlist-url-extractor.md
+++ b/src/AgentInitiator/Prompts/wishlist-url-extractor.md
@@ -1,14 +1,14 @@
 # Wishlist URL Extractor
 
-You are a product extraction specialist for a whiskey, vodka, gin, wine, cocktail, and cigar tracking application.
+You are a product extraction specialist for a drinks, desserts, and cigar tracking application.
 
 You will receive the text content scraped from a product webpage URL. Your job is to extract structured product information suitable for adding to a wishlist.
 
 Extract the following fields:
 - **name**: The specific product name (e.g., "Lagavulin 16 Year Old", "Opus X Robusto")
 - **brand**: The brand or producer (e.g., "Lagavulin", "Arturo Fuente")
-- **type**: Must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, venue, custom
-- **category**: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet", "Robusto", "London Dry Gin")
+- **type**: Must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, dessert, custom
+- **category**: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet", "Robusto", "London Dry Gin", "Cheesecake")
 - **notes**: A concise 1-3 sentence description of the product including key characteristics, tasting notes, or notable features found on the page
 
 ## Rules
@@ -19,6 +19,7 @@ Extract the following fields:
 - For spirits: include region, age, ABV if mentioned
 - For cigars: include wrapper, size, strength if mentioned
 - For wine: include grape, vintage, region if mentioned
+- For desserts: include type, key ingredients, origin if mentioned
 
 ## Output Format
 Respond with ONLY a JSON object (no markdown fences, no explanation):

--- a/src/api/Agents/LocalExtraction.cs
+++ b/src/api/Agents/LocalExtraction.cs
@@ -184,7 +184,7 @@ internal static class LocalExtraction
         if (lower.Contains("vodka") || lower.Contains("smirnoff") || lower.Contains("absolut") || lower.Contains("grey goose")) return ItemType.Vodka;
         if (lower.Contains("gin") || lower.Contains("hendrick") || lower.Contains("tanqueray") || lower.Contains("bombay")) return ItemType.Gin;
         if (lower.Contains("whiskey") || lower.Contains("whisky") || lower.Contains("bourbon") || lower.Contains("scotch")) return ItemType.Whiskey;
-        if (lower.Contains("bar") || lower.Contains("restaurant") || lower.Contains("lounge") || lower.Contains("venue")) return ItemType.Venue;
+        if (lower.Contains("dessert") || lower.Contains("cake") || lower.Contains("pie") || lower.Contains("pastry") || lower.Contains("ice cream") || lower.Contains("cookie") || lower.Contains("brownie") || lower.Contains("cheesecake") || lower.Contains("tiramisu")) return ItemType.Dessert;
         return ItemType.Custom;
     }
 

--- a/src/api/Agents/WorkflowAgentService.cs
+++ b/src/api/Agents/WorkflowAgentService.cs
@@ -30,10 +30,10 @@ public class WorkflowAgentService : IAgentService
 
     private const int MaxRefinements = 2;
 
-    private const string VisionAgentName = "whiskey-smokes-vision-analyst";
-    private const string ExpertAgentName = "whiskey-smokes-domain-expert";
-    private const string CuratorAgentName = "whiskey-smokes-data-curator";
-    private const string NoteAgentName = "whiskey-smokes-note-analyst";
+    private const string VisionAgentName = "dd-vision-analyst";
+    private const string ExpertAgentName = "dd-domain-expert";
+    private const string CuratorAgentName = "dd-data-curator";
+    private const string NoteAgentName = "dd-note-analyst";
 
     public WorkflowAgentService(
         ICosmosDbService cosmosDb,
@@ -385,7 +385,9 @@ public class WorkflowAgentService : IAgentService
             "vodka" => ItemType.Vodka,
             "gin" or "gin and tonic" or "g&t" => ItemType.Gin,
             "cigar" => ItemType.Cigar,
-            "venue" or "bar" or "restaurant" or "lounge" => ItemType.Venue,
+            "dessert" or "cake" or "pie" or "pastry" or "ice cream" or "cookie" or "brownie"
+                or "cheesecake" or "tiramisu" or "crème brûlée" or "mousse" or "tart"
+                or "pudding" or "soufflé" or "macaron" or "chocolate" => ItemType.Dessert,
             _ => ItemType.Custom
         };
     }

--- a/src/api/Controllers/AdminController.cs
+++ b/src/api/Controllers/AdminController.cs
@@ -224,7 +224,7 @@ public class AdminController : ControllerBase
 
             // Invoke the domain expert agent with a trivial prompt to validate the
             // full Foundry pipeline: auth → agent resolution → Responses API → response
-            const string healthCheckAgent = "whiskey-smokes-domain-expert";
+            const string healthCheckAgent = "dd-domain-expert";
             const string healthCheckPrompt = "Reply with exactly: OK";
 
             var agentRef = new Azure.AI.Projects.OpenAI.AgentReference(healthCheckAgent, "1");

--- a/src/api/Controllers/ItemsController.cs
+++ b/src/api/Controllers/ItemsController.cs
@@ -143,7 +143,31 @@ public class ItemsController : ControllerBase
         if (request.Type != null) item.Type = request.Type;
         if (request.Brand != null) item.Brand = request.Brand;
         if (request.Category != null) item.Category = request.Category;
-        if (request.Venue != null) item.Venue = request.Venue;
+        if (request.Venue != null)
+        {
+            item.Venue = request.Venue;
+
+            // Auto-create venue if name provided without venueId
+            if (string.IsNullOrEmpty(request.Venue.VenueId) && !string.IsNullOrWhiteSpace(request.Venue.Name))
+            {
+                try
+                {
+                    var venue = new Venue
+                    {
+                        UserId = userId,
+                        Name = request.Venue.Name.Trim(),
+                        Address = request.Venue.Address?.Trim(),
+                    };
+                    venue = await _cosmosDb.CreateAsync("venues", venue, venue.PartitionKey);
+                    item.Venue.VenueId = venue.Id;
+                    _logger.LogInformation("Auto-created venue {VenueId} ({VenueName}) for item {ItemId}", venue.Id, venue.Name, id);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Failed to auto-create venue for item {ItemId}", id);
+                }
+            }
+        }
         if (request.UserRating.HasValue) item.UserRating = request.UserRating;
         if (request.UserNotes != null) item.UserNotes = request.UserNotes;
         if (!string.IsNullOrWhiteSpace(request.JournalEntry))
@@ -225,7 +249,7 @@ public class ItemsController : ControllerBase
         if (string.IsNullOrWhiteSpace(request.Name))
             return BadRequest(new { message = "Name is required" });
         if (string.IsNullOrWhiteSpace(request.Type) || !ItemType.All.Contains(request.Type))
-            return BadRequest(new { message = "Valid type is required (whiskey, wine, cocktail, vodka, gin, cigar)" });
+            return BadRequest(new { message = "Valid type is required (whiskey, wine, cocktail, vodka, gin, cigar, dessert)" });
 
         var item = new Item
         {

--- a/src/api/Controllers/VenuesController.cs
+++ b/src/api/Controllers/VenuesController.cs
@@ -1,0 +1,234 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using WhiskeyAndSmokes.Api;
+using WhiskeyAndSmokes.Api.Models;
+using WhiskeyAndSmokes.Api.Services;
+
+namespace WhiskeyAndSmokes.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize]
+public class VenuesController : ControllerBase
+{
+    private readonly ICosmosDbService _cosmosDb;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly ILogger<VenuesController> _logger;
+    private const string ContainerName = "venues";
+
+    private static readonly HashSet<string> AllowedImageExtensions =
+        [".jpg", ".jpeg", ".png", ".gif", ".webp", ".heic", ".heif"];
+
+    public VenuesController(ICosmosDbService cosmosDb, IBlobStorageService blobStorage, ILogger<VenuesController> logger)
+    {
+        _cosmosDb = cosmosDb;
+        _blobStorage = blobStorage;
+        _logger = logger;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier) ?? throw new UnauthorizedAccessException();
+
+    [HttpGet]
+    public async Task<ActionResult<PagedResponse<Venue>>> ListVenues(
+        [FromQuery] string? type,
+        [FromQuery] string? continuationToken)
+    {
+        var userId = GetUserId();
+
+        System.Linq.Expressions.Expression<Func<Venue, bool>>? predicate = null;
+        if (!string.IsNullOrEmpty(type))
+            predicate = v => v.Type == type;
+
+        var (venues, nextToken) = await _cosmosDb.QueryAsync(ContainerName, userId, continuationToken, predicate: predicate);
+
+        _logger.LogInformation("Listed {Count} venues for user {UserId}", venues.Count, userId);
+        return Ok(new PagedResponse<Venue>
+        {
+            Items = venues,
+            ContinuationToken = nextToken,
+            HasMore = nextToken != null
+        });
+    }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<Venue>> GetVenue(string id)
+    {
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        return Ok(venue);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Venue>> CreateVenue([FromBody] CreateVenueRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var userId = GetUserId();
+
+        if (!VenueType.All.Contains(request.Type))
+            return BadRequest(new { message = $"Invalid venue type. Must be one of: {string.Join(", ", VenueType.All)}" });
+
+        var venue = new Venue
+        {
+            UserId = userId,
+            Name = request.Name.Trim(),
+            Address = request.Address?.Trim(),
+            Website = request.Website?.Trim(),
+            Type = request.Type,
+            Rating = request.Rating,
+            Location = request.Location,
+        };
+
+        venue = await _cosmosDb.CreateAsync(ContainerName, venue, venue.PartitionKey);
+
+        _logger.LogInformation("Created venue {VenueId} ({VenueName}) for user {UserId}", venue.Id, venue.Name, userId);
+        return CreatedAtAction(nameof(GetVenue), new { id = venue.Id }, venue);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<ActionResult<Venue>> UpdateVenue(string id, [FromBody] UpdateVenueRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        if (request.Name != null) venue.Name = request.Name.Trim();
+        if (request.Address != null) venue.Address = request.Address.Trim();
+        if (request.Website != null) venue.Website = request.Website.Trim();
+        if (request.Type != null)
+        {
+            if (!VenueType.All.Contains(request.Type))
+                return BadRequest(new { message = $"Invalid venue type. Must be one of: {string.Join(", ", VenueType.All)}" });
+            venue.Type = request.Type;
+        }
+        if (request.Rating.HasValue) venue.Rating = request.Rating;
+        if (request.Location != null) venue.Location = request.Location;
+        venue.UpdatedAt = DateTime.UtcNow;
+
+        venue = await _cosmosDb.UpsertAsync(ContainerName, venue, venue.PartitionKey);
+
+        _logger.LogInformation("Updated venue {VenueId} for user {UserId}", id, userId);
+        return Ok(venue);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteVenue(string id)
+    {
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NoContent();
+
+        // Delete venue photos from blob storage
+        foreach (var photoUrl in venue.PhotoUrls)
+        {
+            try
+            {
+                await _blobStorage.DeleteBlobAsync(photoUrl);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to delete venue photo blob {Url}", photoUrl);
+            }
+        }
+
+        await _cosmosDb.DeleteAsync(ContainerName, id, userId);
+
+        _logger.LogInformation("Deleted venue {VenueId} for user {UserId}", id, userId);
+        return NoContent();
+    }
+
+    [HttpGet("{id}/items")]
+    public async Task<ActionResult<PagedResponse<Item>>> GetVenueItems(string id, [FromQuery] string? continuationToken)
+    {
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        var (items, nextToken) = await _cosmosDb.QueryAsync<Item>("items", userId, continuationToken,
+            predicate: i => i.Venue != null && i.Venue.VenueId == id);
+
+        return Ok(new PagedResponse<Item>
+        {
+            Items = items,
+            ContinuationToken = nextToken,
+            HasMore = nextToken != null
+        });
+    }
+
+    [HttpGet("{id}/photos/upload-url")]
+    public async Task<ActionResult<UploadUrlResponse>> GetPhotoUploadUrl(string id, [FromQuery] string fileName)
+    {
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        if (string.IsNullOrWhiteSpace(fileName))
+            return BadRequest(new { message = "fileName is required" });
+
+        var ext = Path.GetExtension(fileName).ToLowerInvariant();
+        if (!AllowedImageExtensions.Contains(ext))
+            return BadRequest(new { message = $"File type {ext} is not allowed. Accepted: jpg, jpeg, png, gif, webp, heic, heif" });
+
+        var (uploadUrl, blobUrl) = await _blobStorage.GenerateUploadUrlAsync(userId, fileName);
+        return Ok(new UploadUrlResponse { UploadUrl = uploadUrl, BlobUrl = blobUrl });
+    }
+
+    [HttpPost("{id}/photos")]
+    public async Task<ActionResult<Venue>> AddPhoto(string id, [FromBody] AddPhotoRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        if (!venue.PhotoUrls.Contains(request.BlobUrl))
+        {
+            venue.PhotoUrls.Add(request.BlobUrl);
+            venue.UpdatedAt = DateTime.UtcNow;
+            venue = await _cosmosDb.UpsertAsync(ContainerName, venue, venue.PartitionKey);
+        }
+
+        _logger.LogInformation("Added photo to venue {VenueId}, total: {Count}", id, venue.PhotoUrls.Count);
+        return Ok(venue);
+    }
+
+    [HttpDelete("{id}/photos")]
+    public async Task<ActionResult<Venue>> RemovePhoto(string id, [FromBody] RemovePhotoRequest request)
+    {
+        if (!ModelState.IsValid) return BadRequest(ModelState);
+
+        var userId = GetUserId();
+        var venue = await _cosmosDb.GetAsync<Venue>(ContainerName, id, userId);
+        if (venue == null)
+            return NotFound();
+
+        if (venue.PhotoUrls.Remove(request.BlobUrl))
+        {
+            venue.UpdatedAt = DateTime.UtcNow;
+            venue = await _cosmosDb.UpsertAsync(ContainerName, venue, venue.PartitionKey);
+
+            try
+            {
+                await _blobStorage.DeleteBlobAsync(request.BlobUrl);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to delete venue photo blob");
+            }
+        }
+
+        return Ok(venue);
+    }
+}

--- a/src/api/Models/ApiModels.cs
+++ b/src/api/Models/ApiModels.cs
@@ -313,3 +313,59 @@ public class RemovePhotoRequest
     [StringLength(2048)]
     public string BlobUrl { get; set; } = string.Empty;
 }
+
+// Venue
+public class CreateVenueRequest
+{
+    [JsonPropertyName("name")]
+    [Required]
+    [StringLength(200)]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("address")]
+    [StringLength(500)]
+    public string? Address { get; set; }
+
+    [JsonPropertyName("website")]
+    [StringLength(2048)]
+    [Url]
+    public string? Website { get; set; }
+
+    [JsonPropertyName("type")]
+    [Required]
+    [StringLength(50)]
+    public string Type { get; set; } = "other";
+
+    [JsonPropertyName("rating")]
+    [Range(0, 5)]
+    public double? Rating { get; set; }
+
+    [JsonPropertyName("location")]
+    public GeoLocation? Location { get; set; }
+}
+
+public class UpdateVenueRequest
+{
+    [JsonPropertyName("name")]
+    [StringLength(200)]
+    public string? Name { get; set; }
+
+    [JsonPropertyName("address")]
+    [StringLength(500)]
+    public string? Address { get; set; }
+
+    [JsonPropertyName("website")]
+    [StringLength(2048)]
+    public string? Website { get; set; }
+
+    [JsonPropertyName("type")]
+    [StringLength(50)]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("rating")]
+    [Range(0, 5)]
+    public double? Rating { get; set; }
+
+    [JsonPropertyName("location")]
+    public GeoLocation? Location { get; set; }
+}

--- a/src/api/Models/Item.cs
+++ b/src/api/Models/Item.cs
@@ -15,7 +15,7 @@ public class Item
     public string CaptureId { get; set; } = string.Empty;
 
     [JsonPropertyName("type")]
-    public string Type { get; set; } = string.Empty; // whiskey, wine, cocktail, cigar
+    public string Type { get; set; } = string.Empty; // whiskey, wine, cocktail, cigar, dessert
 
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
@@ -71,6 +71,9 @@ public class Item
 
 public class VenueInfo
 {
+    [JsonPropertyName("venueId")]
+    public string? VenueId { get; set; }
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
@@ -101,10 +104,10 @@ public static class ItemType
     public const string Vodka = "vodka";
     public const string Gin = "gin";
     public const string Cigar = "cigar";
-    public const string Venue = "venue";
+    public const string Dessert = "dessert";
     public const string Custom = "custom";
 
-    public static readonly string[] All = [Whiskey, Wine, Cocktail, Vodka, Gin, Cigar, Venue, Custom];
+    public static readonly string[] All = [Whiskey, Wine, Cocktail, Vodka, Gin, Cigar, Dessert, Custom];
 }
 
 public static class ItemStatus

--- a/src/api/Models/Venue.cs
+++ b/src/api/Models/Venue.cs
@@ -7,11 +7,26 @@ public class Venue
     [JsonPropertyName("id")]
     public string Id { get; set; } = Guid.NewGuid().ToString();
 
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
     [JsonPropertyName("name")]
     public string Name { get; set; } = string.Empty;
 
     [JsonPropertyName("address")]
     public string? Address { get; set; }
+
+    [JsonPropertyName("website")]
+    public string? Website { get; set; }
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = VenueType.Other;
+
+    [JsonPropertyName("rating")]
+    public double? Rating { get; set; }
+
+    [JsonPropertyName("photoUrls")]
+    public List<string> PhotoUrls { get; set; } = [];
 
     [JsonPropertyName("location")]
     public GeoLocation? Location { get; set; }
@@ -22,6 +37,19 @@ public class Venue
     [JsonPropertyName("createdAt")]
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
+    [JsonPropertyName("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
     [JsonPropertyName("partitionKey")]
-    public string PartitionKey => Id;
+    public string PartitionKey => UserId;
+}
+
+public static class VenueType
+{
+    public const string Bar = "bar";
+    public const string Lounge = "lounge";
+    public const string Restaurant = "restaurant";
+    public const string Other = "other";
+
+    public static readonly string[] All = [Bar, Lounge, Restaurant, Other];
 }

--- a/src/api/Services/AgentValidationService.cs
+++ b/src/api/Services/AgentValidationService.cs
@@ -15,11 +15,11 @@ public class AgentValidationService : IHostedService
 
     public static readonly string[] RequiredAgents =
     [
-        "whiskey-smokes-vision-analyst",
-        "whiskey-smokes-domain-expert",
-        "whiskey-smokes-data-curator",
-        "whiskey-smokes-note-analyst",
-        "whiskey-smokes-wishlist-url-extractor",
+        "dd-vision-analyst",
+        "dd-domain-expert",
+        "dd-data-curator",
+        "dd-note-analyst",
+        "dd-wishlist-url-extractor",
     ];
 
     public AgentValidationService(

--- a/src/api/Services/PromptService.cs
+++ b/src/api/Services/PromptService.cs
@@ -82,7 +82,7 @@ public class PromptService : IPromptService
              "Legacy monolithic prompt. Replaced by the 3 specialized agent prompts below.",
              DefaultPrompts.AgentInstructions),
             (PromptIds.VisionAnalyst, "Vision Analyst",
-             "Examines uploaded photos and describes visible items — bottles, labels, glasses, cigar bands, menus. Used by the Vision Analyst agent (gpt-4o).",
+             "Examines uploaded photos and describes visible items — bottles, labels, glasses, cigar bands, plates, desserts. Used by the Vision Analyst agent (gpt-4o).",
              DefaultPrompts.VisionAnalyst),
             (PromptIds.DomainExpert, "Domain Expert",
              "Identifies specific products from visual descriptions and adds expert knowledge — tasting notes, origins, flavor profiles. Used by the Domain Expert agent (gpt-5.1-mini).",
@@ -122,27 +122,28 @@ public class PromptService : IPromptService
 public static class DefaultPrompts
 {
     public const string AgentInstructions = """
-        You are an expert sommelier, mixologist, and tobacconist assistant. Your job is to analyze photos 
-        and user notes about drinks (whiskey, vodka, gin, wine, cocktails) and cigars, then extract structured data.
+        You are an expert sommelier, mixologist, tobacconist, and pastry connoisseur. Your job is to analyze photos 
+        and user notes about drinks (whiskey, vodka, gin, wine, cocktails), cigars, and desserts, then extract structured data.
 
-        IMPORTANT: Focus on the 1-3 PRIMARY items the user is capturing. A typical capture is a single 
-        drink or cigar at a bar. Do NOT enumerate every item visible in a menu, shelf, or background.
-        Only create items for things the user is clearly focused on or explicitly mentioned.
+        IMPORTANT: Focus on the 1-3 PRIMARY items in the foreground of the image that the user is capturing.
+        A typical capture is a single drink, cigar, or dessert at a restaurant. Do NOT enumerate every item 
+        visible in a menu, shelf, or background. Ignore anything not clearly in the foreground.
 
         For each distinct item you identify (maximum 3), extract:
-        - type: "whiskey", "wine", "cocktail", "vodka", "gin", "cigar", "venue", or "custom"
+        - type: "whiskey", "wine", "cocktail", "vodka", "gin", "cigar", "dessert", or "custom"
         - name: The specific product name (e.g., "Lagavulin 16 Year Old")
         - brand: The brand/producer (e.g., "Lagavulin")
-        - category: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet", "Robusto")
+        - category: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet", "Robusto", "Cheesecake")
         - details: An object with type-specific fields:
           - For whiskey: region, age, abv, mashBill, flavorNotes[]
           - For wine: grape, vintage, region, winery, flavorNotes[]
           - For cocktail: baseSpirit, ingredients[], recipe, flavorProfile
           - For cigar: wrapper, binder, filler, size, strength, flavorNotes[]
+          - For dessert: dessertType, keyIngredients[], origin, flavorNotes[]
         - venue: { name, address } if you can determine from context
         - confidence: 0.0-1.0 how confident you are in the identification
         - summary: A 1-2 sentence tasting note or description
-        - tags: relevant tags like ["smoky", "peaty", "full-bodied"]
+        - tags: relevant tags like ["smoky", "peaty", "full-bodied", "chocolate", "fruity"]
 
         Return a JSON array of at most 3 items. Always respond with valid JSON array only, no markdown.
         
@@ -151,32 +152,35 @@ public static class DefaultPrompts
         """;
 
     public const string VisionAnalyst = """
-        You are a vision analysis specialist for a whiskey, vodka, gin, wine, cocktail, and cigar tracking application.
+        You are a vision analysis specialist for a drinks, desserts, and cigar tracking application.
         
-        Your job is to carefully examine the provided photos and describe the PRIMARY items the user 
-        is capturing — typically 1-2 drinks or cigars they are personally enjoying.
+        Your job is to carefully examine the provided photos and describe the PRIMARY items in the foreground
+        that the user is capturing — typically 1-2 drinks, desserts, or cigars they are personally enjoying.
 
-        Focus on the MAIN SUBJECT of each photo. Describe at most 3 distinct items:
-        1. **What you see**: The physical object (bottle, glass, cigar, label, band)
+        IMPORTANT: Focus ONLY on items clearly in the foreground of the image. Ignore background items such
+        as other tables, shelves, menus, or items belonging to other people.
+
+        Focus on the MAIN SUBJECT of each photo. Describe at most 3 distinct foreground items:
+        1. **What you see**: The physical object (bottle, glass, cigar, plate, dessert, label, band)
         2. **Text you can read**: Any brand names, product names, vintage years, ABV, origin info on labels
-        3. **Visual characteristics**: Color of liquid, shape of glass, wrapper color of cigar, label design
+        3. **Visual characteristics**: Color of liquid, shape of glass, wrapper color of cigar, plating/garnish of dessert
         4. **Context clues**: Bar/restaurant setting, flight/tasting setup, pairing arrangements
-        5. **Condition/presentation**: How the item is served, garnishes, ice, cut of cigar
+        5. **Condition/presentation**: How the item is served, garnishes, ice, cut of cigar, plating style
 
         If the user provided notes, incorporate that context into your analysis.
         If there's a GPS location, note it for venue identification.
 
         IMPORTANT: Do NOT catalog every bottle on a shelf, every item on a menu, or background items. 
-        Only describe what the user is clearly focused on capturing. If a menu is shown, describe only 
-        the item(s) that appear to be ordered or highlighted, not the full menu.
+        Only describe what the user is clearly focused on capturing in the foreground. If a menu is shown, 
+        describe only the item(s) that appear to be ordered or highlighted, not the full menu.
 
         Respond in plain text with a structured description. Number items if you see more than one (max 3).
         Focus on factual observations — leave product identification to the next stage.
         """;
 
     public const string DomainExpert = """
-        You are a world-class sommelier, master mixologist, and certified tobacconist with encyclopedic
-        knowledge of whiskey, vodka, gin, wine, cocktails, and premium cigars.
+        You are a world-class sommelier, master mixologist, certified tobacconist, and pastry connoisseur
+        with encyclopedic knowledge of whiskey, vodka, gin, wine, cocktails, premium cigars, and desserts.
 
         Given a visual description of items from photos, your job is to:
 
@@ -185,11 +189,11 @@ public static class DefaultPrompts
            - For wine: name, winery, grape varietal, vintage, region (Napa, Bordeaux, Barolo, etc.)
            - For cocktails: name, base spirit, classic recipe, ingredients, garnish
            - For cigars: brand, line, vitola (Robusto, Toro, Churchill, etc.), wrapper/binder/filler, strength
-           - For venues: name, type (bar, lounge, restaurant), notable features
+           - For desserts: name, type (cake, pastry, ice cream, etc.), key ingredients, preparation style, origin
 
         2. **Add expert knowledge**:
            - Tasting notes and flavor profiles based on your knowledge of the product
-           - Recommended pairings (whiskey + cigar, wine + food, etc.)
+           - Recommended pairings (whiskey + cigar, wine + food, dessert + drink, etc.)
            - Historical or notable facts
 
         3. **Set a confidence level** (0.0-1.0):
@@ -198,20 +202,20 @@ public static class DefaultPrompts
            - 0.5-0.7 : Educated guess based on partial information
            - Below 0.5 : Speculative, note what's uncertain
 
-        IMPORTANT: Only identify the 1-3 primary items the user is capturing. Do not add extra items
-        beyond what the vision analyst described. Combine related observations into a single item
-        (e.g., a bottle and the glass poured from it are ONE item, not two).
+        IMPORTANT: Only identify the 1-3 primary items the user is capturing from the foreground.
+        Do not add extra items beyond what the vision analyst described. Combine related observations
+        into a single item (e.g., a bottle and the glass poured from it are ONE item, not two).
 
         Respond in structured text for each item. The data curator will convert to JSON.
         """;
 
     public const string DataCurator = """
-        You are a data quality specialist. Your job is to take the expert analysis of drinks and cigars
+        You are a data quality specialist. Your job is to take the expert analysis of drinks, cigars, and desserts
         and convert it into a precise, validated JSON array matching our schema.
 
         For each item, output a JSON object with these exact fields:
         {
-          "type": "whiskey" | "wine" | "cocktail" | "vodka" | "gin" | "cigar" | "venue" | "custom",
+          "type": "whiskey" | "wine" | "cocktail" | "vodka" | "gin" | "cigar" | "dessert" | "custom",
           "name": "Product Name",
           "brand": "Brand/Producer",
           "category": "Sub-category",
@@ -220,6 +224,7 @@ public static class DefaultPrompts
             // For wine: { "grape", "vintage", "region", "winery", "flavorNotes": [] }
             // For cocktail: { "baseSpirit", "ingredients": [], "recipe", "flavorProfile" }
             // For cigar: { "wrapper", "binder", "filler", "size", "strength", "flavorNotes": [] }
+            // For dessert: { "dessertType", "keyIngredients": [], "origin", "flavorNotes": [] }
           },
           "venue": { "name": "Venue Name", "address": "Address" } | null,
           "confidence": 0.0-1.0,
@@ -228,20 +233,20 @@ public static class DefaultPrompts
         }
 
         VALIDATION RULES:
-        - "type" must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, venue, custom
+        - "type" must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, dessert, custom
         - "name" is required and cannot be empty
         - "confidence" must be a number between 0.0 and 1.0
         - "tags" must be an array of lowercase strings
         - "details" fields must match the type (don't put wine fields in a whiskey item)
         - All text should be properly capitalized (Title Case for names, brands)
-        - MAXIMUM 3 ITEMS per capture. If the expert identified more than 3, keep only the 
-          highest-confidence items. A bottle and the glass poured from it are ONE item.
+        - MAXIMUM 3 ITEMS per capture. Only include items from the foreground of the image.
+          A bottle and the glass poured from it are ONE item.
 
         QUALITY CHECK:
         - If the expert's identification seems inconsistent or has obvious errors, respond with:
           { "decision": "reject", "reason": "explanation of what needs fixing" }
         - If more than 3 items are present, respond with:
-          { "decision": "reject", "reason": "Too many items — keep only the 1-3 primary items" }
+          { "decision": "reject", "reason": "Too many items — keep only the 1-3 primary foreground items" }
         - If the data looks good, respond with:
           { "decision": "approve", "items": [ ... array of validated items (max 3) ... ] }
 
@@ -249,15 +254,15 @@ public static class DefaultPrompts
         """;
 
     public const string WishlistUrlExtractor = """
-        You are a product extraction specialist for a whiskey, vodka, gin, wine, cocktail, and cigar tracking application.
+        You are a product extraction specialist for a drinks, desserts, and cigar tracking application.
 
         You will receive the text content scraped from a product webpage URL. Your job is to extract structured product information suitable for adding to a wishlist.
 
         Extract the following fields:
         - name: The specific product name
         - brand: The brand or producer
-        - type: Must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, venue, custom
-        - category: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet")
+        - type: Must be exactly one of: whiskey, wine, cocktail, vodka, gin, cigar, dessert, custom
+        - category: Sub-category (e.g., "Single Malt Scotch", "Napa Valley Cabernet", "Cheesecake")
         - notes: A concise 1-3 sentence description
 
         Rules:

--- a/src/api/Services/WishlistUrlService.cs
+++ b/src/api/Services/WishlistUrlService.cs
@@ -20,7 +20,7 @@ public class WishlistUrlService : IWishlistUrlService
     private readonly ILogger<WishlistUrlService> _logger;
     private readonly bool _isFoundryConfigured;
 
-    private const string WishlistUrlAgentName = "whiskey-smokes-wishlist-url-extractor";
+    private const string WishlistUrlAgentName = "dd-wishlist-url-extractor";
 
     public WishlistUrlService(
         HttpClient httpClient,

--- a/src/web/index.html
+++ b/src/web/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
-    <title>Whiskey & Smokes</title>
+    <title>Drinks & Desserts</title>
 
     <!-- Favicons -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -14,7 +14,7 @@
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <meta name="apple-mobile-web-app-title" content="W&S" />
+    <meta name="apple-mobile-web-app-title" content="D&D" />
   </head>
   <body>
     <div id="app"></div>

--- a/src/web/src/components/common/AppLayout.vue
+++ b/src/web/src/components/common/AppLayout.vue
@@ -25,7 +25,7 @@ const navItems = [
   { name: 'Collection', path: '/items' },
   { name: 'History', path: '/history' },
   { name: 'Capture', path: '/capture' },
-  { name: 'Stats', path: '/stats' },
+  { name: 'Venues', path: '/venues' },
   { name: 'Profile', path: '/profile' },
 ]
 </script>
@@ -34,7 +34,7 @@ const navItems = [
   <div class="min-h-screen flex flex-col">
     <!-- Header -->
     <header class="bg-stone-900 border-b border-stone-800 px-4 py-3 flex items-center justify-between safe-area-top">
-      <h1 class="text-lg font-bold text-amber-500">Whiskey &amp; Smokes</h1>
+      <h1 class="text-lg font-bold text-amber-500">Drinks &amp; Desserts</h1>
       <button
         v-if="auth.isAuthenticated"
         @click="auth.logout()"
@@ -121,6 +121,11 @@ const navItems = [
             <!-- Stats -->
             <svg v-else-if="item.path === '/stats'" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+            </svg>
+            <!-- Venues -->
+            <svg v-else-if="item.path === '/venues'" xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
             </svg>
             <!-- Profile -->
             <svg v-else xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 mb-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -45,6 +45,17 @@ const routes = [
     component: () => import('../views/ProfileView.vue'),
   },
   {
+    path: '/venues',
+    name: 'Venues',
+    component: () => import('../views/VenuesView.vue'),
+  },
+  {
+    path: '/venues/:id',
+    name: 'VenueDetail',
+    component: () => import('../views/VenueDetailView.vue'),
+    props: true,
+  },
+  {
     path: '/stats',
     name: 'Stats',
     component: () => import('../views/StatsView.vue'),

--- a/src/web/src/services/items.ts
+++ b/src/web/src/services/items.ts
@@ -10,6 +10,7 @@ export interface Item {
   category?: string
   details?: Record<string, unknown>
   venue?: {
+    venueId?: string
     name: string
     address?: string
     placeId?: string
@@ -39,6 +40,7 @@ export interface UpdateItemRequest {
   brand?: string
   category?: string
   venue?: {
+    venueId?: string
     name: string
     address?: string
   }

--- a/src/web/src/services/venues.ts
+++ b/src/web/src/services/venues.ts
@@ -1,0 +1,67 @@
+import api from './api'
+
+export interface Venue {
+  id: string
+  userId: string
+  name: string
+  address?: string
+  website?: string
+  type: string
+  rating?: number
+  photoUrls: string[]
+  location?: { latitude: number; longitude: number }
+  placeId?: string
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateVenueRequest {
+  name: string
+  address?: string
+  website?: string
+  type: string
+  rating?: number
+  location?: { latitude: number; longitude: number }
+}
+
+export interface UpdateVenueRequest {
+  name?: string
+  address?: string
+  website?: string
+  type?: string
+  rating?: number
+  location?: { latitude: number; longitude: number }
+}
+
+export const venuesApi = {
+  list: (type?: string, continuationToken?: string) =>
+    api.get<{ items: Venue[]; continuationToken?: string; hasMore: boolean }>(
+      '/venues', { params: { type, continuationToken } }
+    ),
+
+  get: (id: string) =>
+    api.get<Venue>(`/venues/${id}`),
+
+  create: (data: CreateVenueRequest) =>
+    api.post<Venue>('/venues', data),
+
+  update: (id: string, data: UpdateVenueRequest) =>
+    api.put<Venue>(`/venues/${id}`, data),
+
+  delete: (id: string) =>
+    api.delete(`/venues/${id}`),
+
+  getItems: (id: string, continuationToken?: string) =>
+    api.get<{ items: unknown[]; continuationToken?: string; hasMore: boolean }>(
+      `/venues/${id}/items`, { params: { continuationToken } }
+    ),
+
+  getPhotoUploadUrl: (id: string, fileName: string) =>
+    api.get<{ uploadUrl: string; blobUrl: string }>(`/venues/${id}/photos/upload-url`, { params: { fileName } }),
+
+  addPhoto: (id: string, blobUrl: string) =>
+    api.post<Venue>(`/venues/${id}/photos`, { blobUrl }),
+
+  removePhoto: (id: string, blobUrl: string) =>
+    api.delete<Venue>(`/venues/${id}/photos`, { data: { blobUrl } }),
+}

--- a/src/web/src/stores/venues.ts
+++ b/src/web/src/stores/venues.ts
@@ -1,0 +1,56 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { venuesApi, type Venue, type CreateVenueRequest, type UpdateVenueRequest } from '../services/venues'
+
+export const useVenuesStore = defineStore('venues', () => {
+  const venues = ref<Venue[]>([])
+  const isLoading = ref(false)
+  const continuationToken = ref<string | undefined>()
+
+  async function loadVenues(type?: string, reset = false) {
+    if (reset) {
+      venues.value = []
+      continuationToken.value = undefined
+    }
+    isLoading.value = true
+    try {
+      const { data } = await venuesApi.list(type, continuationToken.value)
+      if (reset) {
+        venues.value = data.items
+      } else {
+        venues.value.push(...data.items)
+      }
+      continuationToken.value = data.continuationToken
+    } finally {
+      isLoading.value = false
+    }
+  }
+
+  async function createVenue(request: CreateVenueRequest): Promise<Venue> {
+    const { data } = await venuesApi.create(request)
+    venues.value.unshift(data)
+    return data
+  }
+
+  async function updateVenue(id: string, request: UpdateVenueRequest): Promise<Venue> {
+    const { data } = await venuesApi.update(id, request)
+    const idx = venues.value.findIndex(v => v.id === id)
+    if (idx >= 0) venues.value[idx] = data
+    return data
+  }
+
+  async function deleteVenue(id: string) {
+    await venuesApi.delete(id)
+    venues.value = venues.value.filter(v => v.id !== id)
+  }
+
+  return {
+    venues,
+    isLoading,
+    continuationToken,
+    loadVenues,
+    createVenue,
+    updateVenue,
+    deleteVenue,
+  }
+})

--- a/src/web/src/views/ItemDetailView.vue
+++ b/src/web/src/views/ItemDetailView.vue
@@ -113,7 +113,7 @@ const typeOptions = [
   { label: 'Vodka', value: 'vodka' },
   { label: 'Gin', value: 'gin' },
   { label: 'Cigar', value: 'cigar' },
-  { label: 'Venue', value: 'venue' },
+  { label: 'Dessert', value: 'dessert' },
   { label: 'Custom', value: 'custom' },
 ]
 

--- a/src/web/src/views/ItemsView.vue
+++ b/src/web/src/views/ItemsView.vue
@@ -60,7 +60,7 @@ const typeFilters = [
   { label: 'Vodka', value: 'vodka' },
   { label: 'Gin', value: 'gin' },
   { label: 'Cigar', value: 'cigar' },
-  { label: 'Venue', value: 'venue' },
+  { label: 'Dessert', value: 'dessert' },
   { label: 'Custom', value: 'custom' },
 ]
 
@@ -71,7 +71,7 @@ const typeOptions = [
   { label: 'Vodka', value: 'vodka' },
   { label: 'Gin', value: 'gin' },
   { label: 'Cigar', value: 'cigar' },
-  { label: 'Venue', value: 'venue' },
+  { label: 'Dessert', value: 'dessert' },
   { label: 'Custom', value: 'custom' },
 ]
 

--- a/src/web/src/views/LoginView.vue
+++ b/src/web/src/views/LoginView.vue
@@ -65,8 +65,8 @@ function toggleMode() {
 <template>
   <div class="flex flex-col items-center justify-center min-h-screen px-6">
     <div class="text-center mb-10">
-      <h1 class="text-5xl font-bold text-amber-500 mb-2">Whiskey &amp; Smokes</h1>
-      <p class="text-stone-400 text-lg">Track your whiskey, vodka, gin, wine, cocktails & cigars</p>
+      <h1 class="text-5xl font-bold text-amber-500 mb-2">Drinks &amp; Desserts</h1>
+      <p class="text-stone-400 text-lg">Track your drinks, desserts & cigars</p>
     </div>
 
     <!-- Microsoft sign-in -->

--- a/src/web/src/views/ProfileView.vue
+++ b/src/web/src/views/ProfileView.vue
@@ -26,7 +26,7 @@ const filterOptions = [
   { label: 'Vodka', value: 'vodka' as string | undefined },
   { label: 'Gin', value: 'gin' as string | undefined },
   { label: 'Cigar', value: 'cigar' as string | undefined },
-  { label: 'Venue', value: 'venue' as string | undefined },
+  { label: 'Dessert', value: 'dessert' as string | undefined },
   { label: 'Custom', value: 'custom' as string | undefined },
 ]
 
@@ -108,7 +108,7 @@ async function exportData() {
     const url = URL.createObjectURL(blob)
     const link = document.createElement('a')
     link.href = url
-    link.download = `whiskey-and-smokes-export-${new Date().toISOString().slice(0, 10)}.zip`
+    link.download = `drinks-and-desserts-export-${new Date().toISOString().slice(0, 10)}.zip`
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)

--- a/src/web/src/views/StatsView.vue
+++ b/src/web/src/views/StatsView.vue
@@ -84,6 +84,9 @@ const typeColors: Record<string, string> = {
   wine: 'bg-red-700',
   cocktail: 'bg-sky-600',
   cigar: 'bg-stone-600',
+  dessert: 'bg-pink-600',
+  vodka: 'bg-blue-500',
+  gin: 'bg-emerald-600',
 }
 
 const typeTextColors: Record<string, string> = {
@@ -91,6 +94,9 @@ const typeTextColors: Record<string, string> = {
   wine: 'text-red-400',
   cocktail: 'text-sky-400',
   cigar: 'text-stone-400',
+  dessert: 'text-pink-400',
+  vodka: 'text-blue-400',
+  gin: 'text-emerald-400',
 }
 
 function typeColor(type: string) {

--- a/src/web/src/views/VenueDetailView.vue
+++ b/src/web/src/views/VenueDetailView.vue
@@ -1,0 +1,240 @@
+<script setup lang="ts">
+import { ref, inject, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { venuesApi, type Venue } from '../services/venues'
+import { type Item } from '../services/items'
+import { RefreshKey } from '../composables/refreshKey'
+import StarRating from '../components/common/StarRating.vue'
+
+const route = useRoute()
+const router = useRouter()
+const registerRefresh = inject(RefreshKey)
+
+const venue = ref<Venue | null>(null)
+const linkedItems = ref<Item[]>([])
+const isEditing = ref(false)
+const isDeleting = ref(false)
+const isSaving = ref(false)
+
+const editName = ref('')
+const editAddress = ref('')
+const editWebsite = ref('')
+const editType = ref('other')
+const editRating = ref(0)
+
+const venueTypeOptions = [
+  { label: 'Bar', value: 'bar' },
+  { label: 'Lounge', value: 'lounge' },
+  { label: 'Restaurant', value: 'restaurant' },
+  { label: 'Other', value: 'other' },
+]
+
+async function refreshVenue() {
+  const id = route.params.id as string
+  const { data } = await venuesApi.get(id)
+  venue.value = data
+  resetEditFields(data)
+
+  try {
+    const { data: itemsData } = await venuesApi.getItems(id)
+    linkedItems.value = itemsData.items as Item[]
+  } catch {
+    linkedItems.value = []
+  }
+}
+
+registerRefresh?.(refreshVenue)
+
+onMounted(refreshVenue)
+
+function resetEditFields(data: Venue) {
+  editName.value = data.name
+  editAddress.value = data.address ?? ''
+  editWebsite.value = data.website ?? ''
+  editType.value = data.type
+  editRating.value = data.rating ?? 0
+}
+
+function startEditing() {
+  if (venue.value) resetEditFields(venue.value)
+  isEditing.value = true
+}
+
+async function saveEdits() {
+  if (!venue.value) return
+  isSaving.value = true
+  try {
+    const { data } = await venuesApi.update(venue.value.id, {
+      name: editName.value.trim(),
+      address: editAddress.value.trim() || undefined,
+      website: editWebsite.value.trim() || undefined,
+      type: editType.value,
+      rating: editRating.value || undefined,
+    })
+    venue.value = data
+    isEditing.value = false
+  } finally {
+    isSaving.value = false
+  }
+}
+
+async function deleteVenue() {
+  if (!venue.value) return
+  isDeleting.value = true
+  try {
+    await venuesApi.delete(venue.value.id)
+    router.replace('/venues')
+  } finally {
+    isDeleting.value = false
+  }
+}
+
+const photoUrls = computed(() => venue.value?.photoUrls ?? [])
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto" v-if="venue">
+    <!-- Back button -->
+    <button @click="router.back()" class="text-stone-400 hover:text-stone-200 text-sm mb-4 flex items-center gap-1">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" />
+      </svg>
+      Back
+    </button>
+
+    <!-- Photos -->
+    <div v-if="photoUrls.length" class="mb-4 -mx-4">
+      <div class="flex gap-2 px-4 overflow-x-auto">
+        <img
+          v-for="url in photoUrls"
+          :key="url"
+          :src="url"
+          class="w-32 h-32 object-cover rounded-xl shrink-0"
+        />
+      </div>
+    </div>
+
+    <!-- View mode -->
+    <template v-if="!isEditing">
+      <div class="space-y-4">
+        <div>
+          <span class="text-xs px-2 py-0.5 rounded-full bg-stone-800 text-stone-400 capitalize">{{ venue.type }}</span>
+          <h2 class="text-2xl font-bold text-stone-100 mt-2">{{ venue.name }}</h2>
+        </div>
+
+        <div v-if="venue.rating" class="flex items-center gap-2">
+          <StarRating :rating="venue.rating" size="md" />
+        </div>
+
+        <div v-if="venue.address" class="text-stone-400 text-sm">{{ venue.address }}</div>
+
+        <a v-if="venue.website" :href="venue.website" target="_blank" class="text-amber-500 text-sm hover:text-amber-400 block truncate">
+          {{ venue.website }}
+        </a>
+
+        <div class="flex gap-2">
+          <button
+            @click="startEditing"
+            class="flex-1 bg-amber-700 hover:bg-amber-600 text-white py-2.5 min-h-[44px] rounded-xl text-sm font-medium"
+          >
+            Edit
+          </button>
+          <button
+            @click="deleteVenue"
+            :disabled="isDeleting"
+            class="px-4 py-2.5 min-h-[44px] bg-stone-800 text-red-400 hover:bg-stone-700 rounded-xl text-sm"
+          >
+            {{ isDeleting ? 'Deleting...' : 'Delete' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Linked items -->
+      <div v-if="linkedItems.length" class="mt-6">
+        <h3 class="text-sm font-medium text-stone-400 mb-3">Linked Items</h3>
+        <div class="space-y-2">
+          <router-link
+            v-for="item in linkedItems"
+            :key="item.id"
+            :to="`/items/${item.id}`"
+            class="block bg-stone-900 border border-stone-800 rounded-xl p-3 hover:border-stone-700 transition-colors"
+          >
+            <div class="flex items-center gap-3">
+              <img
+                v-if="item.photoUrls?.length"
+                :src="item.photoUrls[0]"
+                class="w-10 h-10 object-cover rounded-lg shrink-0"
+              />
+              <div class="flex-1 min-w-0">
+                <span class="text-xs px-2 py-0.5 rounded-full bg-stone-800 text-stone-400">{{ item.type }}</span>
+                <h4 class="font-medium text-stone-100 truncate text-sm">{{ item.name }}</h4>
+              </div>
+            </div>
+          </router-link>
+        </div>
+      </div>
+    </template>
+
+    <!-- Edit mode -->
+    <template v-else>
+      <div class="space-y-4">
+        <div>
+          <label class="block text-sm text-stone-400 mb-1">Name</label>
+          <input
+            v-model="editName"
+            class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm focus:outline-none focus:border-amber-700"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm text-stone-400 mb-1">Type</label>
+          <select
+            v-model="editType"
+            class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm focus:outline-none focus:border-amber-700 appearance-none"
+          >
+            <option v-for="opt in venueTypeOptions" :key="opt.value" :value="opt.value">
+              {{ opt.label }}
+            </option>
+          </select>
+        </div>
+
+        <div>
+          <label class="block text-sm text-stone-400 mb-1">Address</label>
+          <input
+            v-model="editAddress"
+            class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm focus:outline-none focus:border-amber-700"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm text-stone-400 mb-1">Website</label>
+          <input
+            v-model="editWebsite"
+            class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm focus:outline-none focus:border-amber-700"
+          />
+        </div>
+
+        <div>
+          <label class="block text-sm text-stone-400 mb-1">Rating</label>
+          <StarRating :rating="editRating" size="lg" interactive @update:rating="editRating = $event" />
+        </div>
+
+        <div class="flex gap-2">
+          <button
+            @click="saveEdits"
+            :disabled="isSaving"
+            class="flex-1 bg-amber-700 hover:bg-amber-600 disabled:bg-stone-700 disabled:text-stone-500 text-white py-2.5 min-h-[44px] rounded-xl text-sm font-medium"
+          >
+            {{ isSaving ? 'Saving...' : 'Save' }}
+          </button>
+          <button
+            @click="isEditing = false"
+            class="px-4 py-2.5 min-h-[44px] bg-stone-800 text-stone-400 rounded-xl text-sm hover:bg-stone-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/web/src/views/VenuesView.vue
+++ b/src/web/src/views/VenuesView.vue
@@ -1,0 +1,169 @@
+<script setup lang="ts">
+import { ref, inject, onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useVenuesStore } from '../stores/venues'
+import { RefreshKey } from '../composables/refreshKey'
+import StarRating from '../components/common/StarRating.vue'
+
+const router = useRouter()
+const venuesStore = useVenuesStore()
+const registerRefresh = inject(RefreshKey)
+
+const showAddForm = ref(false)
+const newName = ref('')
+const newType = ref('restaurant')
+const newAddress = ref('')
+const newWebsite = ref('')
+const isAdding = ref(false)
+
+const venueTypeOptions = [
+  { label: 'Bar', value: 'bar' },
+  { label: 'Lounge', value: 'lounge' },
+  { label: 'Restaurant', value: 'restaurant' },
+  { label: 'Other', value: 'other' },
+]
+
+registerRefresh?.(async () => {
+  await venuesStore.loadVenues(undefined, true)
+})
+
+onMounted(() => {
+  venuesStore.loadVenues(undefined, true)
+})
+
+const sortedVenues = computed(() => {
+  return [...venuesStore.venues].sort((a, b) => {
+    const ra = a.rating ?? 0
+    const rb = b.rating ?? 0
+    if (rb !== ra) return rb - ra
+    return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
+  })
+})
+
+async function addVenue() {
+  if (!newName.value.trim()) return
+  isAdding.value = true
+  try {
+    const venue = await venuesStore.createVenue({
+      name: newName.value.trim(),
+      type: newType.value,
+      address: newAddress.value.trim() || undefined,
+      website: newWebsite.value.trim() || undefined,
+    })
+    newName.value = ''
+    newAddress.value = ''
+    newWebsite.value = ''
+    showAddForm.value = false
+    router.push(`/venues/${venue.id}`)
+  } finally {
+    isAdding.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto">
+    <h2 class="text-xl font-bold text-stone-100 mb-4">Venues</h2>
+
+    <!-- Add button + form -->
+    <div class="mb-4">
+      <button
+        v-if="!showAddForm"
+        @click="showAddForm = true"
+        class="w-full bg-stone-900 border border-dashed border-stone-700 rounded-xl p-3 text-stone-400 hover:border-stone-500 hover:text-stone-300 transition-colors text-sm"
+      >
+        + Add venue
+      </button>
+
+      <div v-else class="bg-stone-900 border border-stone-800 rounded-xl p-4 space-y-3">
+        <input
+          v-model="newName"
+          placeholder="Name (required)"
+          class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm placeholder-stone-600 focus:outline-none focus:border-amber-700"
+        />
+
+        <select
+          v-model="newType"
+          class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm focus:outline-none focus:border-amber-700 appearance-none"
+        >
+          <option v-for="opt in venueTypeOptions" :key="opt.value" :value="opt.value">
+            {{ opt.label }}
+          </option>
+        </select>
+
+        <input
+          v-model="newAddress"
+          placeholder="Address (optional)"
+          class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm placeholder-stone-600 focus:outline-none focus:border-amber-700"
+        />
+
+        <input
+          v-model="newWebsite"
+          placeholder="Website (optional)"
+          class="w-full bg-stone-800 border border-stone-700 rounded-xl px-4 py-2.5 text-stone-100 text-sm placeholder-stone-600 focus:outline-none focus:border-amber-700"
+        />
+
+        <div class="flex gap-2">
+          <button
+            @click="addVenue"
+            :disabled="isAdding || !newName.trim()"
+            class="flex-1 bg-amber-700 hover:bg-amber-600 disabled:bg-stone-700 disabled:text-stone-500 text-white py-2.5 rounded-xl text-sm font-medium"
+          >
+            {{ isAdding ? 'Adding...' : 'Add' }}
+          </button>
+          <button
+            @click="showAddForm = false"
+            class="px-4 py-2.5 bg-stone-800 text-stone-400 rounded-xl text-sm hover:bg-stone-700"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Loading -->
+    <div v-if="venuesStore.isLoading && !sortedVenues.length" class="text-stone-500 text-center py-12">
+      Loading...
+    </div>
+
+    <!-- Empty -->
+    <div v-else-if="!sortedVenues.length" class="text-stone-500 text-center py-12">
+      <p>No venues yet. Add your favorite spots.</p>
+    </div>
+
+    <!-- Venue list -->
+    <div v-else class="space-y-3">
+      <router-link
+        v-for="venue in sortedVenues"
+        :key="venue.id"
+        :to="`/venues/${venue.id}`"
+        class="block bg-stone-900 border border-stone-800 rounded-xl p-4 hover:border-stone-700 transition-colors"
+      >
+        <div class="flex items-start gap-3">
+          <img
+            v-if="venue.photoUrls.length"
+            :src="venue.photoUrls[0]"
+            class="w-16 h-16 object-cover rounded-lg shrink-0"
+          />
+          <div v-else class="w-16 h-16 bg-stone-800 rounded-lg shrink-0 flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-stone-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z" />
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+            </svg>
+          </div>
+
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-xs px-2 py-0.5 rounded-full bg-stone-800 text-stone-400 capitalize">{{ venue.type }}</span>
+            </div>
+            <h3 class="font-medium text-stone-100 truncate">{{ venue.name }}</h3>
+            <p v-if="venue.address" class="text-sm text-stone-500 truncate">{{ venue.address }}</p>
+            <div v-if="venue.rating" class="mt-1">
+              <StarRating :rating="venue.rating" size="sm" />
+            </div>
+          </div>
+        </div>
+      </router-link>
+    </div>
+  </div>
+</template>

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -11,9 +11,9 @@ export default defineConfig({
       registerType: 'autoUpdate',
       includeAssets: ['favicon.svg', 'favicon-64.png', 'apple-touch-icon.png'],
       manifest: {
-        name: 'Whiskey & Smokes',
-        short_name: 'W&S',
-        description: 'Track your whiskey, vodka, gin, wine, cocktail, and cigar experiences',
+        name: 'Drinks & Desserts',
+        short_name: 'D&D',
+        description: 'Track your drinks, desserts, and cigar experiences',
         theme_color: '#0c0a09',
         background_color: '#0c0a09',
         display: 'standalone',


### PR DESCRIPTION
…nues

- Rebrand from 'Whiskey & Smokes' to 'Drinks & Desserts' across UI, PWA manifest, and login
- Add 'dessert' as new item type with AI prompt support for dessert identification
- Remove 'venue' as item type; venues are now standalone entities
- Redesign Venue model with UserId, Website, Type, Rating, PhotoUrls, UpdatedAt
- Add VenuesController with full CRUD, photo management, and linked items
- Add venue auto-create when setting venue on item updates
- Add VenueInfo.VenueId for item-venue association
- Create frontend venues service, store, list view, and detail view
- Add Venues tab to bottom navigation (replacing Stats in nav)
- Rename AI agents from whiskey-smokes-* to dd-*
- Update all prompts to add dessert expertise and foreground-focus language
- Add dessert type colors to StatsView
- Update type filters/options across all views