### PR TITLE
Adds a complete Friends social feature to Drinks & Desserts, enabling users to connect via invite links, browse each other's collections and venues, and leave thoughts (comments + ratings) on items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,60 @@
-# Whiskey & Smokes
+# Drinks & Desserts
 
-Track your whiskey, wine, cocktails, cigars, and venues. Snap a photo at the bar, let AI do the rest, refine later.
+Track your drinks, desserts, and venues. Snap a photo, let AI do the rest, refine later. Share your collection with friends.
 
 ## Features
 
 - **Photo Capture** with AI-powered item identification (1-3 items per capture)
-- **Six item types**: Whiskey, Wine, Cocktail, Cigar, Venue, and Custom
+- **Seven item types**: Whiskey, Wine, Cocktail, Cigar, Dessert, Venue, and Custom
+- **Venues** — capture bars, restaurants, and lounges with name, address, website, type, rating, and linked items. Create from photos or extract from URLs (including Google Maps links)
+- **Friends** — invite friends via shareable links, browse each other's collections and venues, leave thoughts (comments + ratings) on items
+- **Notifications** — in-app notification bell for friend requests, new thoughts, and social activity
 - **Star ratings** with half/quarter star precision
 - **Journal entries** for tasting notes and thoughts
 - **Wishlist** to track items you want to try
 - **Collection stats** with breakdowns by type
+- **Search** across your entire collection
 - **Sorting** by rating, date added, or date updated (configurable default in settings)
 - **Filtering** by item type via dropdown menu
-- **Autocomplete** for name, brand, and tags based on your existing collection
+- **Autocomplete** for name, brand, tags, and venue labels based on your existing data
 - **Photo management** on items (add, remove photos after capture)
 - **External API** for iOS Shortcuts and other integrations (API key auth)
-- **PWA support** — installable on iOS/Android with offline-capable service worker
+- **PWA support** — installable on iOS/Android with offline-capable service worker and refresh tokens
 
 ## Architecture
 
-- **Frontend**: Vue 3 + TypeScript + TailwindCSS (mobile-first PWA)
+- **Frontend**: Vue 3.5 + TypeScript + Tailwind CSS 4 (mobile-first PWA)
 - **Backend**: .NET 10 Web API
 - **AI Pipeline**: Multi-agent workflow via [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) (1.0.0-rc4)
 - **Orchestration**: .NET Aspire AppHost (OpenTelemetry dashboard)
-- **Database**: Azure CosmosDB (prod) / LiteDB (local dev)
+- **Database**: Azure CosmosDB (prod) / LiteDB (local dev) — 8 containers
 - **Storage**: Azure Blob Storage (prod) / local filesystem (local dev)
 - **AI Models**: Azure AI Foundry — gpt-4o (vision) + gpt-5-mini (reasoning)
 - **Observability**: OpenTelemetry → Azure Application Insights + Aspire Dashboard
-- **Auth**: JWT (local/self-hosted) / Azure Entra ID (prod) / API keys (external integrations)
+- **Auth**: JWT with refresh tokens (local/self-hosted) / Azure Entra ID (prod) / API keys (external integrations)
 - **Infra**: Terraform → Azure Container Apps (API) + Static Web App (frontend)
 - **CI/CD**: GitHub Actions — PR checks, Azure deployment, Docker Hub publishing
+
+### CosmosDB Containers
+
+| Container | Partition Key | Description |
+|-----------|--------------|-------------|
+| `users` | `/partitionKey` (userId) | User accounts and preferences |
+| `captures` | `/partitionKey` (userId) | Photo captures and AI workflow results |
+| `items` | `/partitionKey` (userId) | Collection items (drinks, desserts, cigars) |
+| `venues` | `/partitionKey` (userId) | Venues (bars, restaurants, lounges) |
+| `friendships` | `/partitionKey` (userId) | Dual-document friendship records |
+| `friend-invites` | `/partitionKey` (invite code) | Invite codes for friend discovery |
+| `thoughts` | `/partitionKey` (targetUserId) | Friend thoughts/comments on items and venues |
+| `notifications` | `/partitionKey` (userId) | In-app notification records |
+
+### Friendship Dual-Document Pattern
+
+Each friendship creates two CosmosDB documents — one in each user's partition. This enables efficient per-user queries (list my friends) without cross-partition reads. When User A and User B become friends:
+- Document in A's partition: `{ userId: A, friendId: B, status: "accepted" }`
+- Document in B's partition: `{ userId: B, friendId: A, status: "accepted" }`
+
+Invite flow: sharing a link auto-accepts (the inviter pre-approved by sharing). The joiner clicking the link creates the friendship immediately.
 
 ## AI Pipeline
 
@@ -73,6 +98,45 @@ When AI Foundry is not configured, the system falls back to keyword-based local 
 | [Local Docker Deployment](docs/local-docker-deployment.md) | Self-hosted deployment with Docker Compose and Portainer |
 | [Azure Deployment](docs/azure-deployment.md) | Terraform stacks, GitHub Actions, OIDC setup, secrets & variables |
 
+## Friends API
+
+Friends feature enables social sharing between users. All endpoints require authentication (`MultiAuth` or `ApiKey`).
+
+### Friends
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/friends` | List accepted friends |
+| `GET` | `/api/friends/requests` | List sent and received friend requests |
+| `POST` | `/api/friends/invite` | Generate an 8-char invite code (7-day expiry) |
+| `POST` | `/api/friends/join/{code}` | Join via invite code (auto-accepts) |
+| `PUT` | `/api/friends/{id}/accept` | Accept a pending friend request |
+| `PUT` | `/api/friends/{id}/decline` | Decline a pending friend request |
+| `DELETE` | `/api/friends/{id}` | Remove a friend (deletes both sides) |
+| `GET` | `/api/friends/{friendId}/items` | Browse a friend's collection items |
+| `GET` | `/api/friends/{friendId}/items/{itemId}` | Get a specific friend's item |
+| `GET` | `/api/friends/{friendId}/venues` | Browse a friend's venues |
+| `GET` | `/api/friends/{friendId}/venues/{venueId}` | Get a specific friend's venue |
+
+### Thoughts
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/thoughts/{targetType}/{targetId}?targetUserId=` | Get thoughts on an item or venue (`targetType`: `item` or `venue`) |
+| `POST` | `/api/thoughts` | Leave a thought on a friend's item/venue (body: `content`, `targetUserId`, `targetType`, `targetId`, optional `rating` 1-5) |
+| `PUT` | `/api/thoughts/{id}` | Edit own thought (body: `content`, optional `rating`) |
+| `DELETE` | `/api/thoughts/{id}` | Delete own thought |
+| `GET` | `/api/thoughts/mine` | Get all thoughts you've written |
+| `GET` | `/api/thoughts/on-my-items` | Get all thoughts others left on your items/venues |
+
+### Notifications
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/notifications?limit=50` | List notifications (max 200, returns `{ notifications, unreadCount }`) |
+| `PUT` | `/api/notifications/{id}/read` | Mark a single notification as read |
+| `PUT` | `/api/notifications/read-all` | Mark all notifications as read |
+
 ## Quick Start
 
 ```bash
@@ -111,13 +175,16 @@ Access the admin panel at `/admin` (requires admin role — the first registered
 
 ## Security
 
-- JWT tokens for authentication; API key auth for external integrations
+- JWT tokens with refresh token rotation for authentication; API key auth for external integrations
+- Friendship validation on all cross-user data access endpoints (IDOR protection)
 - Path traversal protection on all file upload/download endpoints
 - Server-side file type validation (allowlisted image extensions only)
 - Blob URL ownership validation (users can only modify their own photos)
 - AI call timeouts (3 minutes) to prevent thread starvation
 - Prompt injection mitigation with explicit input delimiters
 - Constant-time API key hash comparison
+- Invite codes: 8-char alphanumeric (no ambiguous chars), 7-day expiry, single-use
+- Thought content validated (500 char limit, rating 1-5 range)
 - Production startup fails if JWT secret is not configured
 
 ## Project Structure
@@ -130,17 +197,25 @@ src/
       AuthController            Registration, login, Entra ID sign-in
       CapturesController        Photo capture + AI processing
       ItemsController           Collection CRUD, photo management, suggestions
+      VenuesController          Venue CRUD, URL extraction, logo extraction
+      FriendsController         Friend invites, accept/decline, browse friend data
+      ThoughtsController        Comments + ratings on friends' items and venues
+      NotificationsController   In-app notification list and read status
       ExternalController        External API for iOS Shortcuts (API key auth)
       UsersController           Profile, preferences, API key management
       AdminController           User management, prompts, logging, diagnostics
       UploadsController         Local file upload/download (dev/self-hosted)
-    Models/                     Domain models (Capture, Item, User, Prompt)
-    Services/                   Business logic (Auth, CosmosDB, Blob, Prompts)
+    Models/                     Domain models (Capture, Item, User, Venue, Friendship, Thought, Notification)
+    Services/                   Business logic (Auth, CosmosDB, Blob, Prompts, Notifications)
   AgentInitiator/               CLI tool -- creates/recreates agents in Foundry
     Prompts/                    Agent prompt markdown files
   AppHost/                      .NET Aspire orchestrator
   ServiceDefaults/              Shared OpenTelemetry, health checks
-  web/                          Vue 3 Frontend (PWA)
+  web/                          Vue 3.5 Frontend (PWA)
+    src/views/                  Page views (Collection, ItemDetail, Venues, Friends, etc.)
+    src/components/common/      Reusable components (StarRating, NotificationBell, ThoughtsList, etc.)
+    src/services/               API client modules (items, venues, friends, thoughts, notifications)
+    src/stores/                 Pinia state stores (auth, items, venues)
   WhiskeyAndSmokes.sln
 infrastructure/
   local/                        Terraform -- local dev (AI Foundry only)
@@ -150,6 +225,8 @@ tasks/                          Taskfile configs + Docker Compose files
   docker-compose.local.test.yml   Local dev services (Aspire dashboard)
   docker-compose.local.prod.yml   Self-hosted build-from-source deployment
   docker-compose.portainer.yml    Self-hosted pre-built image deployment
+tests/
+  WhiskeyAndSmokes.Tests/       xUnit v3 integration tests (55 tests)
 docs/
   local-development.md
   local-docker-deployment.md

--- a/src/api/Controllers/FriendsController.cs
+++ b/src/api/Controllers/FriendsController.cs
@@ -1,0 +1,319 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using WhiskeyAndSmokes.Api.Models;
+using WhiskeyAndSmokes.Api.Services;
+
+namespace WhiskeyAndSmokes.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(AuthenticationSchemes = "MultiAuth,ApiKey")]
+public class FriendsController : ControllerBase
+{
+    private readonly ICosmosDbService _cosmosDb;
+    private readonly INotificationService _notificationService;
+    private readonly ILogger<FriendsController> _logger;
+    private const string FriendshipsContainer = "friendships";
+    private const string InvitesContainer = "friend-invites";
+
+    public FriendsController(ICosmosDbService cosmosDb, INotificationService notificationService, ILogger<FriendsController> logger)
+    {
+        _cosmosDb = cosmosDb;
+        _notificationService = notificationService;
+        _logger = logger;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier) ?? throw new UnauthorizedAccessException();
+    private string GetDisplayName() => User.FindFirstValue(ClaimTypes.Name) ?? "Unknown";
+    private string GetEmail() => User.FindFirstValue(ClaimTypes.Email) ?? "";
+
+    // ── Friends list ──
+
+    [HttpGet]
+    public async Task<ActionResult<List<Friendship>>> ListFriends()
+    {
+        var userId = GetUserId();
+        var (friends, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, userId, maxItems: 100,
+            predicate: f => f.Status == FriendshipStatus.Accepted);
+        return Ok(friends);
+    }
+
+    [HttpGet("requests")]
+    public async Task<ActionResult<object>> ListRequests()
+    {
+        var userId = GetUserId();
+        var (all, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, userId, maxItems: 100,
+            predicate: f => f.Status == FriendshipStatus.PendingSent || f.Status == FriendshipStatus.PendingReceived);
+
+        var sent = all.Where(f => f.Status == FriendshipStatus.PendingSent).ToList();
+        var received = all.Where(f => f.Status == FriendshipStatus.PendingReceived).ToList();
+        return Ok(new { sent, received });
+    }
+
+    // ── Invite generation ──
+
+    [HttpPost("invite")]
+    public async Task<ActionResult<FriendInvite>> CreateInvite()
+    {
+        var userId = GetUserId();
+        var invite = new FriendInvite
+        {
+            UserId = userId,
+            UserDisplayName = GetDisplayName(),
+        };
+
+        await _cosmosDb.CreateAsync(InvitesContainer, invite, invite.PartitionKey);
+        _logger.LogInformation("User {UserId} created friend invite {InviteId}", userId, invite.Id);
+        return Ok(invite);
+    }
+
+    // ── Join via invite code ──
+
+    [HttpPost("join/{code}")]
+    public async Task<ActionResult> JoinViaInvite(string code)
+    {
+        var userId = GetUserId();
+        var invite = await _cosmosDb.GetAsync<FriendInvite>(InvitesContainer, code.ToUpperInvariant(), code.ToUpperInvariant());
+
+        if (invite == null || !invite.IsActive || invite.ExpiresAt < DateTime.UtcNow)
+            return NotFound(new { error = "Invite not found or expired." });
+
+        if (invite.UsedBy.Count >= invite.MaxUses)
+            return BadRequest(new { error = "This invite has already been used." });
+
+        if (invite.UserId == userId)
+            return BadRequest(new { error = "You cannot use your own invite." });
+
+        // Check if already friends or pending
+        var (existing, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, userId, maxItems: 1,
+            predicate: f => f.FriendId == invite.UserId);
+
+        if (existing.Count > 0)
+        {
+            var status = existing[0].Status;
+            if (status == FriendshipStatus.Accepted)
+                return BadRequest(new { error = "You are already friends." });
+            if (status == FriendshipStatus.PendingSent || status == FriendshipStatus.PendingReceived)
+                return BadRequest(new { error = "A friend request is already pending." });
+        }
+
+        // Get inviter's user info
+        var inviter = await _cosmosDb.GetAsync<User>("users", invite.UserId, invite.UserId);
+        var inviterName = inviter?.DisplayName ?? invite.UserDisplayName;
+        var inviterEmail = inviter?.Email;
+
+        // Create dual friendship docs
+        var myDoc = new Friendship
+        {
+            UserId = userId,
+            FriendId = invite.UserId,
+            FriendDisplayName = inviterName,
+            FriendEmail = inviterEmail,
+            Status = FriendshipStatus.PendingReceived,
+        };
+
+        var theirDoc = new Friendship
+        {
+            UserId = invite.UserId,
+            FriendId = userId,
+            FriendDisplayName = GetDisplayName(),
+            FriendEmail = GetEmail(),
+            Status = FriendshipStatus.PendingSent,
+        };
+
+        // Wait — actually the joiner is accepting the invite, so the inviter sent it.
+        // The inviter's doc should be "pending-sent" and the joiner's doc is "pending-received"
+        // But for invite flow, the joiner needs to confirm. Let's make it:
+        // Inviter = pending-sent (they initiated by sharing the link)
+        // Joiner = pending-received (they need to accept)
+        // Actually, the joiner clicking the link IS the acceptance from their side.
+        // The inviter still needs to see it. Let's auto-accept from joiner side:
+        // Inviter gets pending-received (needs to accept), Joiner gets pending-sent
+
+        // Re-think: invite link = inviter is offering friendship
+        // Joiner clicking = joiner wants to accept
+        // So: inviter has pending-received (confirm the joiner), joiner has pending-sent
+        // Actually simplest UX: clicking invite = instant friendship (inviter pre-approved by sharing link)
+        myDoc.Status = FriendshipStatus.Accepted;
+        theirDoc.Status = FriendshipStatus.Accepted;
+
+        await _cosmosDb.CreateAsync(FriendshipsContainer, myDoc, myDoc.PartitionKey);
+        await _cosmosDb.CreateAsync(FriendshipsContainer, theirDoc, theirDoc.PartitionKey);
+
+        // Mark invite used
+        invite.UsedBy.Add(userId);
+        if (invite.UsedBy.Count >= invite.MaxUses)
+            invite.IsActive = false;
+        await _cosmosDb.UpsertAsync(InvitesContainer, invite, invite.PartitionKey);
+
+        // Notify the inviter
+        await _notificationService.CreateAsync(new Notification
+        {
+            UserId = invite.UserId,
+            Type = NotificationType.FriendAccepted,
+            Title = $"{GetDisplayName()} accepted your friend invite",
+            SourceUserId = userId,
+            SourceDisplayName = GetDisplayName(),
+            ReferenceType = "friendship",
+            ReferenceId = theirDoc.Id,
+        });
+
+        _logger.LogInformation("User {UserId} joined via invite {InviteId} from {InviterId}", userId, code, invite.UserId);
+        return Ok(new { friendshipId = myDoc.Id, friendDisplayName = inviterName });
+    }
+
+    // ── Accept / Decline ──
+
+    [HttpPut("{friendshipId}/accept")]
+    public async Task<ActionResult> AcceptRequest(string friendshipId)
+    {
+        var userId = GetUserId();
+        var myDoc = await _cosmosDb.GetAsync<Friendship>(FriendshipsContainer, friendshipId, userId);
+        if (myDoc == null || myDoc.UserId != userId || myDoc.Status != FriendshipStatus.PendingReceived)
+            return NotFound();
+
+        myDoc.Status = FriendshipStatus.Accepted;
+        myDoc.UpdatedAt = DateTime.UtcNow;
+        await _cosmosDb.UpsertAsync(FriendshipsContainer, myDoc, myDoc.PartitionKey);
+
+        // Update the other side
+        var (theirDocs, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, myDoc.FriendId, maxItems: 1,
+            predicate: f => f.FriendId == userId && f.Status == FriendshipStatus.PendingSent);
+
+        if (theirDocs.Count > 0)
+        {
+            var theirDoc = theirDocs[0];
+            theirDoc.Status = FriendshipStatus.Accepted;
+            theirDoc.UpdatedAt = DateTime.UtcNow;
+            await _cosmosDb.UpsertAsync(FriendshipsContainer, theirDoc, theirDoc.PartitionKey);
+        }
+
+        await _notificationService.CreateAsync(new Notification
+        {
+            UserId = myDoc.FriendId,
+            Type = NotificationType.FriendAccepted,
+            Title = $"{GetDisplayName()} accepted your friend request",
+            SourceUserId = userId,
+            SourceDisplayName = GetDisplayName(),
+            ReferenceType = "friendship",
+            ReferenceId = myDoc.Id,
+        });
+
+        return Ok();
+    }
+
+    [HttpPut("{friendshipId}/decline")]
+    public async Task<ActionResult> DeclineRequest(string friendshipId)
+    {
+        var userId = GetUserId();
+        var myDoc = await _cosmosDb.GetAsync<Friendship>(FriendshipsContainer, friendshipId, userId);
+        if (myDoc == null || myDoc.UserId != userId || myDoc.Status != FriendshipStatus.PendingReceived)
+            return NotFound();
+
+        myDoc.Status = FriendshipStatus.Declined;
+        myDoc.UpdatedAt = DateTime.UtcNow;
+        await _cosmosDb.UpsertAsync(FriendshipsContainer, myDoc, myDoc.PartitionKey);
+
+        // Update the other side
+        var (theirDocs, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, myDoc.FriendId, maxItems: 1,
+            predicate: f => f.FriendId == userId && f.Status == FriendshipStatus.PendingSent);
+
+        if (theirDocs.Count > 0)
+        {
+            var theirDoc = theirDocs[0];
+            theirDoc.Status = FriendshipStatus.Declined;
+            theirDoc.UpdatedAt = DateTime.UtcNow;
+            await _cosmosDb.UpsertAsync(FriendshipsContainer, theirDoc, theirDoc.PartitionKey);
+        }
+
+        return Ok();
+    }
+
+    // ── Remove friend ──
+
+    [HttpDelete("{friendshipId}")]
+    public async Task<ActionResult> RemoveFriend(string friendshipId)
+    {
+        var userId = GetUserId();
+        var myDoc = await _cosmosDb.GetAsync<Friendship>(FriendshipsContainer, friendshipId, userId);
+        if (myDoc == null || myDoc.UserId != userId)
+            return NotFound();
+
+        await _cosmosDb.DeleteAsync(FriendshipsContainer, friendshipId, userId);
+
+        // Delete the other side
+        var (theirDocs, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, myDoc.FriendId, maxItems: 1,
+            predicate: f => f.FriendId == userId);
+
+        if (theirDocs.Count > 0)
+            await _cosmosDb.DeleteAsync(FriendshipsContainer, theirDocs[0].Id, myDoc.FriendId);
+
+        _logger.LogInformation("User {UserId} removed friend {FriendId}", userId, myDoc.FriendId);
+        return NoContent();
+    }
+
+    // ── Browse friend's data ──
+
+    [HttpGet("{friendId}/items")]
+    public async Task<ActionResult<PagedResponse<Item>>> GetFriendItems(string friendId, [FromQuery] string? continuationToken)
+    {
+        var userId = GetUserId();
+        if (!await AreFriendsAsync(userId, friendId))
+            return Forbid();
+
+        var (items, nextToken) = await _cosmosDb.QueryAsync<Item>("items", friendId, continuationToken);
+        return Ok(new PagedResponse<Item> { Items = items, ContinuationToken = nextToken, HasMore = nextToken != null });
+    }
+
+    [HttpGet("{friendId}/items/{itemId}")]
+    public async Task<ActionResult<Item>> GetFriendItem(string friendId, string itemId)
+    {
+        var userId = GetUserId();
+        if (!await AreFriendsAsync(userId, friendId))
+            return Forbid();
+
+        var item = await _cosmosDb.GetAsync<Item>("items", itemId, friendId);
+        if (item == null) return NotFound();
+        return Ok(item);
+    }
+
+    [HttpGet("{friendId}/venues")]
+    public async Task<ActionResult<PagedResponse<Venue>>> GetFriendVenues(string friendId, [FromQuery] string? continuationToken)
+    {
+        var userId = GetUserId();
+        if (!await AreFriendsAsync(userId, friendId))
+            return Forbid();
+
+        var (venues, nextToken) = await _cosmosDb.QueryAsync<Venue>("venues", friendId, continuationToken);
+        return Ok(new PagedResponse<Venue> { Items = venues, ContinuationToken = nextToken, HasMore = nextToken != null });
+    }
+
+    [HttpGet("{friendId}/venues/{venueId}")]
+    public async Task<ActionResult<Venue>> GetFriendVenue(string friendId, string venueId)
+    {
+        var userId = GetUserId();
+        if (!await AreFriendsAsync(userId, friendId))
+            return Forbid();
+
+        var venue = await _cosmosDb.GetAsync<Venue>("venues", venueId, friendId);
+        if (venue == null) return NotFound();
+        return Ok(venue);
+    }
+
+    // ── Helpers ──
+
+    private async Task<bool> AreFriendsAsync(string userId, string friendId)
+    {
+        var (friends, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, userId, maxItems: 1,
+            predicate: f => f.FriendId == friendId && f.Status == FriendshipStatus.Accepted);
+        return friends.Count > 0;
+    }
+}

--- a/src/api/Controllers/NotificationsController.cs
+++ b/src/api/Controllers/NotificationsController.cs
@@ -1,0 +1,67 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using WhiskeyAndSmokes.Api.Models;
+using WhiskeyAndSmokes.Api.Services;
+
+namespace WhiskeyAndSmokes.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(AuthenticationSchemes = "MultiAuth,ApiKey")]
+public class NotificationsController : ControllerBase
+{
+    private readonly ICosmosDbService _cosmosDb;
+    private readonly ILogger<NotificationsController> _logger;
+    private const string ContainerName = "notifications";
+
+    public NotificationsController(ICosmosDbService cosmosDb, ILogger<NotificationsController> logger)
+    {
+        _cosmosDb = cosmosDb;
+        _logger = logger;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier) ?? throw new UnauthorizedAccessException();
+
+    [HttpGet]
+    public async Task<ActionResult<object>> ListNotifications([FromQuery] int limit = 50)
+    {
+        var userId = GetUserId();
+        var (notifications, _) = await _cosmosDb.QueryAsync<Notification>(
+            ContainerName, userId, maxItems: limit);
+
+        var sorted = notifications.OrderByDescending(n => n.CreatedAt).ToList();
+        var unreadCount = sorted.Count(n => !n.IsRead);
+
+        return Ok(new { notifications = sorted, unreadCount });
+    }
+
+    [HttpPut("{id}/read")]
+    public async Task<ActionResult> MarkRead(string id)
+    {
+        var userId = GetUserId();
+        var notification = await _cosmosDb.GetAsync<Notification>(ContainerName, id, userId);
+        if (notification == null || notification.UserId != userId) return NotFound();
+
+        notification.IsRead = true;
+        await _cosmosDb.UpsertAsync(ContainerName, notification, notification.PartitionKey);
+        return Ok();
+    }
+
+    [HttpPut("read-all")]
+    public async Task<ActionResult> MarkAllRead()
+    {
+        var userId = GetUserId();
+        var (notifications, _) = await _cosmosDb.QueryAsync<Notification>(
+            ContainerName, userId, maxItems: 200,
+            predicate: n => !n.IsRead);
+
+        foreach (var n in notifications)
+        {
+            n.IsRead = true;
+            await _cosmosDb.UpsertAsync(ContainerName, n, n.PartitionKey);
+        }
+
+        return Ok(new { updated = notifications.Count });
+    }
+}

--- a/src/api/Controllers/NotificationsController.cs
+++ b/src/api/Controllers/NotificationsController.cs
@@ -27,8 +27,9 @@ public class NotificationsController : ControllerBase
     public async Task<ActionResult<object>> ListNotifications([FromQuery] int limit = 50)
     {
         var userId = GetUserId();
+        var clampedLimit = Math.Clamp(limit, 1, 200);
         var (notifications, _) = await _cosmosDb.QueryAsync<Notification>(
-            ContainerName, userId, maxItems: limit);
+            ContainerName, userId, maxItems: clampedLimit);
 
         var sorted = notifications.OrderByDescending(n => n.CreatedAt).ToList();
         var unreadCount = sorted.Count(n => !n.IsRead);

--- a/src/api/Controllers/ThoughtsController.cs
+++ b/src/api/Controllers/ThoughtsController.cs
@@ -1,0 +1,231 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using WhiskeyAndSmokes.Api.Models;
+using WhiskeyAndSmokes.Api.Services;
+
+namespace WhiskeyAndSmokes.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+[Authorize(AuthenticationSchemes = "MultiAuth,ApiKey")]
+public class ThoughtsController : ControllerBase
+{
+    private readonly ICosmosDbService _cosmosDb;
+    private readonly INotificationService _notificationService;
+    private readonly ILogger<ThoughtsController> _logger;
+    private const string ContainerName = "thoughts";
+    private const string FriendshipsContainer = "friendships";
+
+    public ThoughtsController(ICosmosDbService cosmosDb, INotificationService notificationService, ILogger<ThoughtsController> logger)
+    {
+        _cosmosDb = cosmosDb;
+        _notificationService = notificationService;
+        _logger = logger;
+    }
+
+    private string GetUserId() => User.FindFirstValue(ClaimTypes.NameIdentifier) ?? throw new UnauthorizedAccessException();
+    private string GetDisplayName() => User.FindFirstValue(ClaimTypes.Name) ?? "Unknown";
+
+    /// <summary>Get all thoughts on a specific item or venue (partitioned by target owner).</summary>
+    [HttpGet("{targetType}/{targetId}")]
+    public async Task<ActionResult<List<Thought>>> GetThoughts(string targetType, string targetId, [FromQuery] string targetUserId)
+    {
+        if (targetType != ThoughtTargetType.Item && targetType != ThoughtTargetType.Venue)
+            return BadRequest(new { error = "targetType must be 'item' or 'venue'." });
+
+        if (string.IsNullOrWhiteSpace(targetUserId))
+            return BadRequest(new { error = "targetUserId is required." });
+
+        var userId = GetUserId();
+
+        // Must be the owner or a friend of the owner
+        if (targetUserId != userId && !await AreFriendsAsync(userId, targetUserId))
+            return Forbid();
+
+        var (thoughts, _) = await _cosmosDb.QueryAsync<Thought>(
+            ContainerName, targetUserId, maxItems: 100,
+            predicate: t => t.TargetId == targetId && t.TargetType == targetType);
+
+        return Ok(thoughts.OrderByDescending(t => t.CreatedAt).ToList());
+    }
+
+    /// <summary>Leave a thought on a friend's item or venue.</summary>
+    [HttpPost]
+    public async Task<ActionResult<Thought>> CreateThought([FromBody] CreateThoughtRequest request)
+    {
+        if (!ModelState.IsValid) return ValidationProblem();
+
+        var userId = GetUserId();
+
+        if (request.TargetUserId == userId)
+            return BadRequest(new { error = "You cannot leave a thought on your own item." });
+
+        if (!await AreFriendsAsync(userId, request.TargetUserId))
+            return Forbid();
+
+        if (request.Rating.HasValue && (request.Rating < 1 || request.Rating > 5))
+            return BadRequest(new { error = "Rating must be between 1 and 5." });
+
+        // Resolve target name
+        var targetName = await ResolveTargetNameAsync(request.TargetType, request.TargetId, request.TargetUserId);
+
+        var thought = new Thought
+        {
+            AuthorId = userId,
+            AuthorDisplayName = GetDisplayName(),
+            TargetUserId = request.TargetUserId,
+            TargetType = request.TargetType,
+            TargetId = request.TargetId,
+            TargetName = targetName ?? "Unknown",
+            Content = request.Content.Trim(),
+            Rating = request.Rating,
+        };
+
+        await _cosmosDb.CreateAsync(ContainerName, thought, thought.PartitionKey);
+
+        // Notify the item/venue owner
+        await _notificationService.CreateAsync(new Notification
+        {
+            UserId = request.TargetUserId,
+            Type = NotificationType.NewThought,
+            Title = $"{GetDisplayName()} shared a thought on {targetName ?? "your " + request.TargetType}",
+            Detail = thought.Content.Length > 100 ? thought.Content[..100] + "..." : thought.Content,
+            SourceUserId = userId,
+            SourceDisplayName = GetDisplayName(),
+            ReferenceType = request.TargetType,
+            ReferenceId = request.TargetId,
+        });
+
+        _logger.LogInformation("User {UserId} left thought on {TargetType}/{TargetId} owned by {OwnerId}",
+            userId, request.TargetType, request.TargetId, request.TargetUserId);
+
+        return Ok(thought);
+    }
+
+    /// <summary>Edit own thought.</summary>
+    [HttpPut("{id}")]
+    public async Task<ActionResult<Thought>> UpdateThought(string id, [FromBody] UpdateThoughtRequest request)
+    {
+        if (!ModelState.IsValid) return ValidationProblem();
+
+        var userId = GetUserId();
+
+        // Thoughts are partitioned by targetUserId — we need to find it
+        // Use cross-partition query to locate the thought by its id
+        var thoughts = await _cosmosDb.QueryCrossPartitionAsync<Thought>(
+            ContainerName,
+            "SELECT * FROM c WHERE c.id = @id AND c.authorId = @authorId",
+            new Dictionary<string, object> { ["@id"] = id, ["@authorId"] = userId },
+            maxItems: 1);
+
+        if (thoughts.Count == 0) return NotFound();
+
+        var thought = thoughts[0];
+        thought.Content = request.Content.Trim();
+        if (request.Rating.HasValue)
+            thought.Rating = request.Rating;
+        thought.UpdatedAt = DateTime.UtcNow;
+
+        await _cosmosDb.UpsertAsync(ContainerName, thought, thought.PartitionKey);
+        return Ok(thought);
+    }
+
+    /// <summary>Delete own thought.</summary>
+    [HttpDelete("{id}")]
+    public async Task<ActionResult> DeleteThought(string id)
+    {
+        var userId = GetUserId();
+
+        var thoughts = await _cosmosDb.QueryCrossPartitionAsync<Thought>(
+            ContainerName,
+            "SELECT * FROM c WHERE c.id = @id AND c.authorId = @authorId",
+            new Dictionary<string, object> { ["@id"] = id, ["@authorId"] = userId },
+            maxItems: 1);
+
+        if (thoughts.Count == 0) return NotFound();
+
+        var thought = thoughts[0];
+        await _cosmosDb.DeleteAsync(ContainerName, id, thought.PartitionKey);
+        return NoContent();
+    }
+
+    /// <summary>Get all thoughts I've written.</summary>
+    [HttpGet("mine")]
+    public async Task<ActionResult<List<Thought>>> GetMyThoughts()
+    {
+        var userId = GetUserId();
+        var thoughts = await _cosmosDb.QueryCrossPartitionAsync<Thought>(
+            ContainerName,
+            "SELECT * FROM c WHERE c.authorId = @authorId ORDER BY c.createdAt DESC",
+            new Dictionary<string, object> { ["@authorId"] = userId },
+            maxItems: 100);
+        return Ok(thoughts);
+    }
+
+    /// <summary>Get all thoughts others left on my items/venues.</summary>
+    [HttpGet("on-my-items")]
+    public async Task<ActionResult<List<Thought>>> GetThoughtsOnMyItems()
+    {
+        var userId = GetUserId();
+        var (thoughts, _) = await _cosmosDb.QueryAsync<Thought>(
+            ContainerName, userId, maxItems: 100);
+        return Ok(thoughts.OrderByDescending(t => t.CreatedAt).ToList());
+    }
+
+    // ── Helpers ──
+
+    private async Task<bool> AreFriendsAsync(string userId, string friendId)
+    {
+        var (friends, _) = await _cosmosDb.QueryAsync<Friendship>(
+            FriendshipsContainer, userId, maxItems: 1,
+            predicate: f => f.FriendId == friendId && f.Status == FriendshipStatus.Accepted);
+        return friends.Count > 0;
+    }
+
+    private async Task<string?> ResolveTargetNameAsync(string targetType, string targetId, string targetUserId)
+    {
+        if (targetType == ThoughtTargetType.Item)
+        {
+            var item = await _cosmosDb.GetAsync<Item>("items", targetId, targetUserId);
+            return item?.Name;
+        }
+        if (targetType == ThoughtTargetType.Venue)
+        {
+            var venue = await _cosmosDb.GetAsync<Venue>("venues", targetId, targetUserId);
+            return venue?.Name;
+        }
+        return null;
+    }
+}
+
+// Request models
+public class CreateThoughtRequest
+{
+    [System.ComponentModel.DataAnnotations.Required]
+    [System.ComponentModel.DataAnnotations.StringLength(500)]
+    public string Content { get; set; } = string.Empty;
+
+    [System.ComponentModel.DataAnnotations.Required]
+    public string TargetUserId { get; set; } = string.Empty;
+
+    [System.ComponentModel.DataAnnotations.Required]
+    [System.ComponentModel.DataAnnotations.RegularExpression("^(item|venue)$")]
+    public string TargetType { get; set; } = string.Empty;
+
+    [System.ComponentModel.DataAnnotations.Required]
+    public string TargetId { get; set; } = string.Empty;
+
+    [System.ComponentModel.DataAnnotations.Range(1, 5)]
+    public int? Rating { get; set; }
+}
+
+public class UpdateThoughtRequest
+{
+    [System.ComponentModel.DataAnnotations.Required]
+    [System.ComponentModel.DataAnnotations.StringLength(500)]
+    public string Content { get; set; } = string.Empty;
+
+    [System.ComponentModel.DataAnnotations.Range(1, 5)]
+    public int? Rating { get; set; }
+}

--- a/src/api/Controllers/ThoughtsController.cs
+++ b/src/api/Controllers/ThoughtsController.cs
@@ -58,6 +58,9 @@ public class ThoughtsController : ControllerBase
 
         var userId = GetUserId();
 
+        if (string.IsNullOrWhiteSpace(request.Content))
+            return BadRequest(new { error = "Content cannot be empty." });
+
         if (request.TargetUserId == userId)
             return BadRequest(new { error = "You cannot leave a thought on your own item." });
 
@@ -108,6 +111,9 @@ public class ThoughtsController : ControllerBase
     public async Task<ActionResult<Thought>> UpdateThought(string id, [FromBody] UpdateThoughtRequest request)
     {
         if (!ModelState.IsValid) return ValidationProblem();
+
+        if (string.IsNullOrWhiteSpace(request.Content))
+            return BadRequest(new { error = "Content cannot be empty." });
 
         var userId = GetUserId();
 

--- a/src/api/Models/FriendInvite.cs
+++ b/src/api/Models/FriendInvite.cs
@@ -34,6 +34,8 @@ public class FriendInvite
     private static string GenerateCode()
     {
         const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-        return new string(Random.Shared.GetItems<char>(chars.AsSpan(), 8));
+        var bytes = new byte[8];
+        System.Security.Cryptography.RandomNumberGenerator.Fill(bytes);
+        return new string(bytes.Select(b => chars[b % chars.Length]).ToArray());
     }
 }

--- a/src/api/Models/FriendInvite.cs
+++ b/src/api/Models/FriendInvite.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace WhiskeyAndSmokes.Api.Models;
+
+public class FriendInvite
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = GenerateCode();
+
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
+    [JsonPropertyName("userDisplayName")]
+    public string UserDisplayName { get; set; } = string.Empty;
+
+    [JsonPropertyName("expiresAt")]
+    public DateTime ExpiresAt { get; set; } = DateTime.UtcNow.AddDays(7);
+
+    [JsonPropertyName("maxUses")]
+    public int MaxUses { get; set; } = 1;
+
+    [JsonPropertyName("usedBy")]
+    public List<string> UsedBy { get; set; } = [];
+
+    [JsonPropertyName("isActive")]
+    public bool IsActive { get; set; } = true;
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey => Id;
+
+    private static string GenerateCode()
+    {
+        const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+        return new string(Random.Shared.GetItems<char>(chars.AsSpan(), 8));
+    }
+}

--- a/src/api/Models/Friendship.cs
+++ b/src/api/Models/Friendship.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace WhiskeyAndSmokes.Api.Models;
+
+public class Friendship
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
+    [JsonPropertyName("friendId")]
+    public string FriendId { get; set; } = string.Empty;
+
+    [JsonPropertyName("friendDisplayName")]
+    public string FriendDisplayName { get; set; } = string.Empty;
+
+    [JsonPropertyName("friendEmail")]
+    public string? FriendEmail { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = FriendshipStatus.PendingSent;
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey => UserId;
+}
+
+public static class FriendshipStatus
+{
+    public const string PendingSent = "pending-sent";
+    public const string PendingReceived = "pending-received";
+    public const string Accepted = "accepted";
+    public const string Declined = "declined";
+    public const string Blocked = "blocked";
+}

--- a/src/api/Models/Notification.cs
+++ b/src/api/Models/Notification.cs
@@ -1,0 +1,49 @@
+using System.Text.Json.Serialization;
+
+namespace WhiskeyAndSmokes.Api.Models;
+
+public class Notification
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [JsonPropertyName("userId")]
+    public string UserId { get; set; } = string.Empty;
+
+    [JsonPropertyName("type")]
+    public string Type { get; set; } = string.Empty;
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("detail")]
+    public string? Detail { get; set; }
+
+    [JsonPropertyName("sourceUserId")]
+    public string SourceUserId { get; set; } = string.Empty;
+
+    [JsonPropertyName("sourceDisplayName")]
+    public string SourceDisplayName { get; set; } = string.Empty;
+
+    [JsonPropertyName("referenceType")]
+    public string? ReferenceType { get; set; }
+
+    [JsonPropertyName("referenceId")]
+    public string? ReferenceId { get; set; }
+
+    [JsonPropertyName("isRead")]
+    public bool IsRead { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey => UserId;
+}
+
+public static class NotificationType
+{
+    public const string FriendRequest = "friend-request";
+    public const string FriendAccepted = "friend-accepted";
+    public const string NewThought = "new-thought";
+}

--- a/src/api/Models/Thought.cs
+++ b/src/api/Models/Thought.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace WhiskeyAndSmokes.Api.Models;
+
+public class Thought
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+
+    [JsonPropertyName("authorId")]
+    public string AuthorId { get; set; } = string.Empty;
+
+    [JsonPropertyName("authorDisplayName")]
+    public string AuthorDisplayName { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetUserId")]
+    public string TargetUserId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetType")]
+    public string TargetType { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetId")]
+    public string TargetId { get; set; } = string.Empty;
+
+    [JsonPropertyName("targetName")]
+    public string TargetName { get; set; } = string.Empty;
+
+    [JsonPropertyName("content")]
+    public string Content { get; set; } = string.Empty;
+
+    [JsonPropertyName("rating")]
+    public int? Rating { get; set; }
+
+    [JsonPropertyName("createdAt")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("updatedAt")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    [JsonPropertyName("partitionKey")]
+    public string PartitionKey => TargetUserId;
+}
+
+public static class ThoughtTargetType
+{
+    public const string Item = "item";
+    public const string Venue = "venue";
+}

--- a/src/api/Program.cs
+++ b/src/api/Program.cs
@@ -207,6 +207,7 @@ builder.Services.AddSingleton<IAuthService, AuthService>();
 builder.Services.AddSingleton<IPromptService, PromptService>();
 builder.Services.AddSingleton<ExifLocationService>();
 builder.Services.AddSingleton<IAgentService, WorkflowAgentService>();
+builder.Services.AddSingleton<INotificationService, NotificationService>();
 builder.Services.AddHttpClient<IWishlistUrlService, WishlistUrlService>();
 builder.Services.AddHttpClient<IVenueUrlService, VenueUrlService>();
 builder.Services.AddHostedService<AgentValidationService>();
@@ -326,8 +327,8 @@ static async Task InitializeCosmosDb(WebApplication app)
 
         var database = await client.CreateDatabaseIfNotExistsAsync(dbName);
 
-        string[] containers = ["users", "captures", "items", "venues"];
-        string[] partitionKeys = ["/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey"];
+        string[] containers = ["users", "captures", "items", "venues", "friendships", "friend-invites", "thoughts", "notifications"];
+        string[] partitionKeys = ["/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey", "/partitionKey"];
 
         for (int i = 0; i < containers.Length; i++)
         {

--- a/src/api/Services/NotificationService.cs
+++ b/src/api/Services/NotificationService.cs
@@ -1,0 +1,35 @@
+using WhiskeyAndSmokes.Api.Models;
+
+namespace WhiskeyAndSmokes.Api.Services;
+
+public interface INotificationService
+{
+    Task CreateAsync(Notification notification);
+}
+
+public class NotificationService : INotificationService
+{
+    private readonly ICosmosDbService _cosmosDb;
+    private readonly ILogger<NotificationService> _logger;
+    private const string ContainerName = "notifications";
+
+    public NotificationService(ICosmosDbService cosmosDb, ILogger<NotificationService> logger)
+    {
+        _cosmosDb = cosmosDb;
+        _logger = logger;
+    }
+
+    public async Task CreateAsync(Notification notification)
+    {
+        try
+        {
+            await _cosmosDb.CreateAsync(ContainerName, notification, notification.PartitionKey);
+            _logger.LogInformation("Created {Type} notification for user {UserId} from {SourceUserId}",
+                notification.Type, notification.UserId, notification.SourceUserId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to create notification for user {UserId}", notification.UserId);
+        }
+    }
+}

--- a/src/web/src/components/common/AppLayout.vue
+++ b/src/web/src/components/common/AppLayout.vue
@@ -4,6 +4,7 @@ import { useAuthStore } from '../../stores/auth'
 import { useRoute } from 'vue-router'
 import { usePullToRefresh } from '../../composables/usePullToRefresh'
 import { RefreshKey } from '../../composables/refreshKey'
+import NotificationBell from './NotificationBell.vue'
 
 const auth = useAuthStore()
 const route = useRoute()
@@ -35,13 +36,16 @@ const navItems = [
     <!-- Header -->
     <header class="bg-[#041e3e] border-b border-[#0a2a52] px-4 py-3 flex items-center justify-between safe-area-top">
       <h1 class="text-lg font-bold text-[#96BEE6]">Drinks &amp; Desserts</h1>
-      <button
-        v-if="auth.isAuthenticated"
-        @click="auth.logout()"
-        class="text-sm text-[#96BEE6] hover:text-white"
-      >
-        Sign Out
-      </button>
+      <div class="flex items-center gap-3">
+        <NotificationBell v-if="auth.isAuthenticated" />
+        <button
+          v-if="auth.isAuthenticated"
+          @click="auth.logout()"
+          class="text-sm text-[#96BEE6] hover:text-white"
+        >
+          Sign Out
+        </button>
+      </div>
     </header>
 
     <!-- Pull-to-refresh indicator -->

--- a/src/web/src/components/common/NotificationBell.vue
+++ b/src/web/src/components/common/NotificationBell.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import { ref, onMounted, onUnmounted } from 'vue'
+import { useRouter } from 'vue-router'
+import { notificationsApi, type AppNotification } from '../../services/notifications'
+
+const router = useRouter()
+const unreadCount = ref(0)
+const showDropdown = ref(false)
+const notifications = ref<AppNotification[]>([])
+const isLoading = ref(false)
+
+async function loadCount() {
+  try {
+    const res = await notificationsApi.list(1)
+    unreadCount.value = res.data.unreadCount
+  } catch { /* silent */ }
+}
+
+async function toggleDropdown() {
+  showDropdown.value = !showDropdown.value
+  if (showDropdown.value && notifications.value.length === 0) {
+    isLoading.value = true
+    try {
+      const res = await notificationsApi.list(20)
+      notifications.value = res.data.notifications
+      unreadCount.value = res.data.unreadCount
+    } catch { /* silent */ }
+    isLoading.value = false
+  }
+}
+
+async function markAllRead() {
+  try {
+    await notificationsApi.markAllRead()
+    notifications.value.forEach(n => n.isRead = true)
+    unreadCount.value = 0
+  } catch { /* silent */ }
+}
+
+async function handleNotificationClick(n: AppNotification) {
+  if (!n.isRead) {
+    try {
+      await notificationsApi.markRead(n.id)
+      n.isRead = true
+      unreadCount.value = Math.max(0, unreadCount.value - 1)
+    } catch { /* silent */ }
+  }
+
+  showDropdown.value = false
+
+  if (n.type === 'friend-request' || n.type === 'friend-accepted') {
+    router.push('/friends')
+  } else if (n.type === 'new-thought' && n.referenceType && n.referenceId) {
+    // Navigate to the item/venue that got the thought
+    router.push(`/${n.referenceType}s/${n.referenceId}`)
+  }
+}
+
+function closeDropdown(e: MouseEvent) {
+  const target = e.target as HTMLElement
+  if (!target.closest('.notification-bell-container')) {
+    showDropdown.value = false
+  }
+}
+
+let refreshInterval: ReturnType<typeof setInterval> | null = null
+
+onMounted(() => {
+  loadCount()
+  refreshInterval = setInterval(loadCount, 60000)
+  window.addEventListener('click', closeDropdown)
+})
+
+onUnmounted(() => {
+  if (refreshInterval) clearInterval(refreshInterval)
+  window.removeEventListener('click', closeDropdown)
+})
+</script>
+
+<template>
+  <div class="notification-bell-container relative">
+    <button @click.stop="toggleDropdown" class="relative p-1 text-[#96BEE6] hover:text-white transition-colors">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+      </svg>
+      <span v-if="unreadCount > 0"
+        class="absolute -top-1 -right-1 w-4 h-4 bg-red-500 rounded-full text-[10px] flex items-center justify-center text-white font-bold">
+        {{ unreadCount > 9 ? '9+' : unreadCount }}
+      </span>
+    </button>
+
+    <!-- Dropdown -->
+    <div v-if="showDropdown"
+      class="absolute right-0 top-8 w-80 max-h-96 overflow-y-auto bg-[#041e3e] border border-[#0a2a52] rounded-xl shadow-xl z-50">
+      <div class="flex items-center justify-between p-3 border-b border-[#0a2a52]">
+        <h3 class="text-sm font-medium text-white">Notifications</h3>
+        <button v-if="unreadCount > 0" @click="markAllRead" class="text-xs text-[#96BEE6] hover:text-white">
+          Mark all read
+        </button>
+      </div>
+
+      <div v-if="isLoading" class="p-4 text-center text-[#5a8ab5] text-sm">Loading...</div>
+
+      <div v-else-if="notifications.length === 0" class="p-4 text-center text-[#5a8ab5] text-sm">
+        No notifications yet
+      </div>
+
+      <div v-else>
+        <button
+          v-for="n in notifications"
+          :key="n.id"
+          @click="handleNotificationClick(n)"
+          class="w-full text-left p-3 border-b border-[#0a2a52]/50 hover:bg-[#0a2a52]/50 transition-colors"
+          :class="n.isRead ? 'opacity-60' : ''"
+        >
+          <div class="flex items-start gap-2">
+            <span v-if="!n.isRead" class="w-2 h-2 bg-[#96BEE6] rounded-full mt-1.5 shrink-0"></span>
+            <div class="flex-1 min-w-0">
+              <p class="text-sm text-white">{{ n.title }}</p>
+              <p v-if="n.detail" class="text-xs text-[#5a8ab5] truncate mt-0.5">{{ n.detail }}</p>
+              <p class="text-xs text-[#4a7aa5] mt-1">{{ new Date(n.createdAt).toLocaleDateString() }}</p>
+            </div>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/web/src/components/common/ThoughtComposer.vue
+++ b/src/web/src/components/common/ThoughtComposer.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+
+const props = defineProps<{
+  showRating?: boolean
+}>()
+
+const emit = defineEmits<{
+  submit: [payload: { content: string; rating?: number }]
+}>()
+
+const content = ref('')
+const rating = ref<number | undefined>(undefined)
+const isSubmitting = ref(false)
+
+async function submit() {
+  if (!content.value.trim()) return
+  isSubmitting.value = true
+  try {
+    emit('submit', {
+      content: content.value.trim(),
+      rating: props.showRating ? rating.value : undefined,
+    })
+    content.value = ''
+    rating.value = undefined
+  } finally {
+    isSubmitting.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 space-y-3">
+    <textarea
+      v-model="content"
+      placeholder="Share your thoughts..."
+      maxlength="500"
+      rows="3"
+      class="w-full bg-[#0a2a52] border border-[#1e407c]/50 rounded-xl px-4 py-3 text-white placeholder-[#4a7aa5] focus:outline-none focus:border-[#1e407c] resize-none"
+    ></textarea>
+
+    <div class="flex items-center justify-between">
+      <div v-if="props.showRating" class="flex items-center gap-2">
+        <span class="text-xs text-[#5a8ab5]">Rate:</span>
+        <button
+          v-for="star in 5"
+          :key="star"
+          @click="rating = rating === star ? undefined : star"
+          class="text-lg"
+          :class="rating && star <= rating ? 'text-[#96BEE6]' : 'text-[#1e407c]/50'"
+        >
+          &#9733;
+        </button>
+      </div>
+      <div v-else />
+
+      <button
+        @click="submit"
+        :disabled="!content.trim() || isSubmitting"
+        class="bg-[#1e407c] hover:bg-[#2a5299] disabled:bg-[#0a2a52] disabled:text-[#4a7aa5]/60 text-white px-4 py-2 rounded-xl text-sm font-medium transition-colors"
+      >
+        {{ isSubmitting ? 'Posting...' : 'Post' }}
+      </button>
+    </div>
+    <p class="text-xs text-[#4a7aa5] text-right">{{ content.length }}/500</p>
+  </div>
+</template>

--- a/src/web/src/components/common/ThoughtsList.vue
+++ b/src/web/src/components/common/ThoughtsList.vue
@@ -1,0 +1,44 @@
+<script setup lang="ts">
+import { type Thought } from '../../services/thoughts'
+import { useAuthStore } from '../../stores/auth'
+
+const props = defineProps<{
+  thoughts: Thought[]
+}>()
+
+const emit = defineEmits<{
+  delete: [thought: Thought]
+}>()
+
+const auth = useAuthStore()
+</script>
+
+<template>
+  <div class="space-y-3">
+    <div v-for="thought in props.thoughts" :key="thought.id"
+      class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4">
+      <div class="flex items-start justify-between mb-2">
+        <div>
+          <span class="font-medium text-white text-sm">{{ thought.authorDisplayName }}</span>
+          <span class="text-xs text-[#4a7aa5] ml-2">{{ new Date(thought.createdAt).toLocaleDateString() }}</span>
+        </div>
+        <button
+          v-if="thought.authorId === auth.user?.id"
+          @click="emit('delete', thought)"
+          class="text-red-400 text-xs hover:text-red-300"
+        >
+          Delete
+        </button>
+      </div>
+      <div v-if="thought.rating" class="mb-1">
+        <span v-for="star in 5" :key="star"
+          :class="star <= thought.rating ? 'text-[#96BEE6]' : 'text-[#1e407c]/50'">&#9733;</span>
+      </div>
+      <p class="text-sm text-[#96BEE6]/80">{{ thought.content }}</p>
+    </div>
+
+    <div v-if="props.thoughts.length === 0" class="text-center text-[#5a8ab5] py-4 text-sm">
+      No thoughts yet. Be the first to share one.
+    </div>
+  </div>
+</template>

--- a/src/web/src/router/index.ts
+++ b/src/web/src/router/index.ts
@@ -71,6 +71,41 @@ const routes = [
     component: () => import('../views/AdminView.vue'),
     meta: { requiresAdmin: true },
   },
+  {
+    path: '/friends',
+    name: 'Friends',
+    component: () => import('../views/FriendsView.vue'),
+  },
+  {
+    path: '/friends/join/:code',
+    name: 'JoinFriend',
+    component: () => import('../views/JoinFriendView.vue'),
+    props: true,
+  },
+  {
+    path: '/friends/:friendId',
+    name: 'FriendCollection',
+    component: () => import('../views/FriendCollectionView.vue'),
+    props: true,
+  },
+  {
+    path: '/friends/:friendId/items/:id',
+    name: 'FriendItemDetail',
+    component: () => import('../views/FriendItemDetailView.vue'),
+    props: true,
+  },
+  {
+    path: '/friends/:friendId/venues',
+    name: 'FriendVenues',
+    component: () => import('../views/FriendVenuesView.vue'),
+    props: true,
+  },
+  {
+    path: '/friends/:friendId/venues/:id',
+    name: 'FriendVenueDetail',
+    component: () => import('../views/FriendVenuesView.vue'),
+    props: true,
+  },
 ]
 
 const router = createRouter({

--- a/src/web/src/services/friends.ts
+++ b/src/web/src/services/friends.ts
@@ -1,0 +1,48 @@
+import api from './api'
+
+export interface Friendship {
+  id: string
+  userId: string
+  friendId: string
+  friendDisplayName: string
+  friendEmail?: string
+  status: 'pending-sent' | 'pending-received' | 'accepted' | 'declined' | 'blocked'
+  createdAt: string
+  updatedAt: string
+}
+
+export interface FriendInvite {
+  id: string
+  userId: string
+  userDisplayName: string
+  expiresAt: string
+  maxUses: number
+  usedBy: string[]
+  isActive: boolean
+  createdAt: string
+}
+
+export interface FriendRequests {
+  sent: Friendship[]
+  received: Friendship[]
+}
+
+export const friendsApi = {
+  list: () => api.get<Friendship[]>('/api/friends'),
+  listRequests: () => api.get<FriendRequests>('/api/friends/requests'),
+  createInvite: () => api.post<FriendInvite>('/api/friends/invite'),
+  joinViaInvite: (code: string) => api.post<{ friendshipId: string; friendDisplayName: string }>(`/api/friends/join/${code}`),
+  accept: (friendshipId: string) => api.put(`/api/friends/${friendshipId}/accept`),
+  decline: (friendshipId: string) => api.put(`/api/friends/${friendshipId}/decline`),
+  remove: (friendshipId: string) => api.delete(`/api/friends/${friendshipId}`),
+
+  // Browse friend data
+  getFriendItems: (friendId: string, continuationToken?: string) =>
+    api.get('/api/friends/' + friendId + '/items', { params: { continuationToken } }),
+  getFriendItem: (friendId: string, itemId: string) =>
+    api.get('/api/friends/' + friendId + '/items/' + itemId),
+  getFriendVenues: (friendId: string, continuationToken?: string) =>
+    api.get('/api/friends/' + friendId + '/venues', { params: { continuationToken } }),
+  getFriendVenue: (friendId: string, venueId: string) =>
+    api.get('/api/friends/' + friendId + '/venues/' + venueId),
+}

--- a/src/web/src/services/notifications.ts
+++ b/src/web/src/services/notifications.ts
@@ -1,0 +1,26 @@
+import api from './api'
+
+export interface AppNotification {
+  id: string
+  userId: string
+  type: 'friend-request' | 'friend-accepted' | 'new-thought'
+  title: string
+  detail?: string
+  sourceUserId: string
+  sourceDisplayName: string
+  referenceType?: string
+  referenceId?: string
+  isRead: boolean
+  createdAt: string
+}
+
+export interface NotificationsResponse {
+  notifications: AppNotification[]
+  unreadCount: number
+}
+
+export const notificationsApi = {
+  list: (limit = 50) => api.get<NotificationsResponse>('/api/notifications', { params: { limit } }),
+  markRead: (id: string) => api.put(`/api/notifications/${id}/read`),
+  markAllRead: () => api.put('/api/notifications/read-all'),
+}

--- a/src/web/src/services/thoughts.ts
+++ b/src/web/src/services/thoughts.ts
@@ -1,0 +1,38 @@
+import api from './api'
+
+export interface Thought {
+  id: string
+  authorId: string
+  authorDisplayName: string
+  targetUserId: string
+  targetType: 'item' | 'venue'
+  targetId: string
+  targetName: string
+  content: string
+  rating?: number
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateThoughtRequest {
+  content: string
+  targetUserId: string
+  targetType: 'item' | 'venue'
+  targetId: string
+  rating?: number
+}
+
+export interface UpdateThoughtRequest {
+  content: string
+  rating?: number
+}
+
+export const thoughtsApi = {
+  getForTarget: (targetType: string, targetId: string, targetUserId: string) =>
+    api.get<Thought[]>(`/api/thoughts/${targetType}/${targetId}`, { params: { targetUserId } }),
+  create: (data: CreateThoughtRequest) => api.post<Thought>('/api/thoughts', data),
+  update: (id: string, data: UpdateThoughtRequest) => api.put<Thought>(`/api/thoughts/${id}`, data),
+  remove: (id: string) => api.delete(`/api/thoughts/${id}`),
+  mine: () => api.get<Thought[]>('/api/thoughts/mine'),
+  onMyItems: () => api.get<Thought[]>('/api/thoughts/on-my-items'),
+}

--- a/src/web/src/views/FriendCollectionView.vue
+++ b/src/web/src/views/FriendCollectionView.vue
@@ -1,0 +1,106 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { friendsApi, type Friendship } from '../services/friends'
+import type { Item } from '../services/items'
+import StarRating from '../components/common/StarRating.vue'
+
+const route = useRoute()
+const router = useRouter()
+const friendId = computed(() => route.params.friendId as string)
+const friend = ref<Friendship | null>(null)
+const items = ref<Item[]>([])
+const isLoading = ref(true)
+const error = ref('')
+const activeTab = ref<'collection' | 'venues'>('collection')
+
+async function load() {
+  isLoading.value = true
+  error.value = ''
+  try {
+    const [friendsRes, itemsRes] = await Promise.all([
+      friendsApi.list(),
+      friendsApi.getFriendItems(friendId.value),
+    ])
+    friend.value = friendsRes.data.find(f => f.friendId === friendId.value) || null
+    items.value = itemsRes.data.items || []
+  } catch {
+    error.value = 'Failed to load friend data'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <button @click="router.push('/friends')" class="text-[#96BEE6] text-sm mb-1">&larr; Friends</button>
+        <h2 class="text-xl font-semibold">{{ friend?.friendDisplayName || 'Friend' }}</h2>
+      </div>
+    </div>
+
+    <!-- Tabs -->
+    <div class="flex gap-2 mb-6">
+      <button
+        @click="activeTab = 'collection'"
+        class="px-4 py-2.5 min-h-[44px] rounded-full text-sm border transition-colors"
+        :class="activeTab === 'collection'
+          ? 'bg-[#1e407c] border-[#1e407c] text-white'
+          : 'bg-[#0a2a52] border-[#1e407c]/50 text-[#96BEE6] hover:border-[#1e407c]'"
+      >
+        Collection ({{ items.length }})
+      </button>
+      <button
+        @click="activeTab = 'venues'; router.push(`/friends/${friendId}/venues`)"
+        class="px-4 py-2.5 min-h-[44px] rounded-full text-sm border transition-colors bg-[#0a2a52] border-[#1e407c]/50 text-[#96BEE6] hover:border-[#1e407c]"
+      >
+        Venues
+      </button>
+    </div>
+
+    <div v-if="error" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 mb-4 text-sm">
+      {{ error }}
+    </div>
+
+    <div v-if="isLoading" class="text-center text-[#5a8ab5] py-12">Loading...</div>
+
+    <div v-else-if="items.length === 0" class="text-center text-[#5a8ab5] py-12">
+      <p>No items in collection yet</p>
+    </div>
+
+    <div v-else class="space-y-3">
+      <router-link
+        v-for="item in items"
+        :key="item.id"
+        :to="`/friends/${friendId}/items/${item.id}`"
+        class="block bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 hover:border-[#1e407c]/50 transition-colors"
+      >
+        <div class="flex items-start gap-3">
+          <img
+            v-if="item.photoUrls?.length"
+            :src="item.photoUrls[0]"
+            class="w-16 h-16 object-cover rounded-lg shrink-0"
+          />
+          <div v-else class="w-16 h-16 bg-[#0a2a52] rounded-lg shrink-0 flex items-center justify-center text-xs text-[#96BEE6]/70 uppercase">
+            {{ item.type }}
+          </div>
+
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-1">
+              <span class="text-xs px-2 py-0.5 rounded-full bg-[#0a2a52] text-[#96BEE6]">{{ item.type }}</span>
+            </div>
+            <h3 class="font-medium text-white truncate">{{ item.name }}</h3>
+            <p v-if="item.brand" class="text-sm text-[#96BEE6]/70 truncate">{{ item.brand }}</p>
+            <div v-if="item.userRating" class="mt-1">
+              <StarRating :rating="item.userRating" size="sm" />
+            </div>
+          </div>
+        </div>
+      </router-link>
+    </div>
+  </div>
+</template>

--- a/src/web/src/views/FriendItemDetailView.vue
+++ b/src/web/src/views/FriendItemDetailView.vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { friendsApi } from '../services/friends'
+import { thoughtsApi, type Thought, type CreateThoughtRequest } from '../services/thoughts'
+import { useAuthStore } from '../stores/auth'
+import type { Item } from '../services/items'
+import StarRating from '../components/common/StarRating.vue'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const friendId = computed(() => route.params.friendId as string)
+const itemId = computed(() => route.params.id as string)
+
+const item = ref<Item | null>(null)
+const thoughts = ref<Thought[]>([])
+const isLoading = ref(true)
+const error = ref('')
+
+// Thought composer
+const newThoughtContent = ref('')
+const newThoughtRating = ref<number | undefined>(undefined)
+const isSubmitting = ref(false)
+
+async function load() {
+  isLoading.value = true
+  error.value = ''
+  try {
+    const [itemRes, thoughtsRes] = await Promise.all([
+      friendsApi.getFriendItem(friendId.value, itemId.value),
+      thoughtsApi.getForTarget('item', itemId.value, friendId.value),
+    ])
+    item.value = itemRes.data
+    thoughts.value = thoughtsRes.data
+  } catch {
+    error.value = 'Failed to load item'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function submitThought() {
+  if (!newThoughtContent.value.trim()) return
+  isSubmitting.value = true
+  try {
+    const req: CreateThoughtRequest = {
+      content: newThoughtContent.value.trim(),
+      targetUserId: friendId.value,
+      targetType: 'item',
+      targetId: itemId.value,
+      rating: newThoughtRating.value,
+    }
+    const res = await thoughtsApi.create(req)
+    thoughts.value.unshift(res.data)
+    newThoughtContent.value = ''
+    newThoughtRating.value = undefined
+  } catch {
+    error.value = 'Failed to post thought'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+async function deleteThought(thought: Thought) {
+  try {
+    await thoughtsApi.remove(thought.id)
+    thoughts.value = thoughts.value.filter(t => t.id !== thought.id)
+  } catch {
+    error.value = 'Failed to delete thought'
+  }
+}
+
+async function saveToWishlist() {
+  if (!item.value) return
+  try {
+    const { default: api } = await import('../services/api')
+    await api.post('/api/items/wishlist', {
+      name: item.value.name,
+      type: item.value.type,
+      brand: item.value.brand,
+      notes: `From ${route.params.friendId}'s collection`,
+      tags: item.value.tags,
+    })
+    alert('Added to your wishlist')
+  } catch {
+    error.value = 'Failed to save to wishlist'
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto">
+    <button @click="router.back()" class="text-[#96BEE6] text-sm mb-4">&larr; Back</button>
+
+    <div v-if="isLoading" class="text-center text-[#5a8ab5] py-12">Loading...</div>
+
+    <div v-else-if="error && !item" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 text-sm">
+      {{ error }}
+    </div>
+
+    <template v-else-if="item">
+      <!-- Item detail -->
+      <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl overflow-hidden mb-4">
+        <img
+          v-if="item.photoUrls?.length"
+          :src="item.photoUrls[0]"
+          class="w-full h-48 object-cover"
+        />
+
+        <div class="p-4 space-y-3">
+          <div class="flex items-center gap-2">
+            <span class="text-xs px-2 py-0.5 rounded-full bg-[#0a2a52] text-[#96BEE6]">{{ item.type }}</span>
+            <span v-if="item.category" class="text-xs text-[#5a8ab5]">{{ item.category }}</span>
+          </div>
+
+          <h2 class="text-xl font-semibold text-white">{{ item.name }}</h2>
+          <p v-if="item.brand" class="text-[#96BEE6]">{{ item.brand }}</p>
+
+          <div v-if="item.userRating">
+            <StarRating :rating="item.userRating" size="md" />
+          </div>
+
+          <p v-if="item.userNotes" class="text-sm text-[#5a8ab5]">{{ item.userNotes }}</p>
+
+          <div v-if="item.venue" class="text-sm text-[#5a8ab5]">
+            Venue: {{ item.venue.name || 'Unknown' }}
+          </div>
+
+          <div v-if="item.tags?.length" class="flex flex-wrap gap-1">
+            <span v-for="tag in item.tags" :key="tag"
+              class="text-xs px-2 py-0.5 rounded-full bg-[#0a2a52] text-[#96BEE6]">
+              {{ tag }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Save to wishlist -->
+      <button
+        @click="saveToWishlist"
+        class="w-full bg-[#0a2a52] border border-[#1e407c]/50 hover:border-[#1e407c] text-[#96BEE6] py-3 rounded-xl font-medium mb-4 transition-colors"
+      >
+        Save to My Wishlist
+      </button>
+
+      <!-- Thoughts section -->
+      <section class="space-y-4">
+        <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">
+          Thoughts ({{ thoughts.length }})
+        </h3>
+
+        <!-- Composer -->
+        <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 space-y-3">
+          <textarea
+            v-model="newThoughtContent"
+            placeholder="Share your thoughts..."
+            maxlength="500"
+            rows="3"
+            class="w-full bg-[#0a2a52] border border-[#1e407c]/50 rounded-xl px-4 py-3 text-white placeholder-[#4a7aa5] focus:outline-none focus:border-[#1e407c] resize-none"
+          ></textarea>
+
+          <div class="flex items-center justify-between">
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-[#5a8ab5]">Rate:</span>
+              <button
+                v-for="star in 5"
+                :key="star"
+                @click="newThoughtRating = newThoughtRating === star ? undefined : star"
+                class="text-lg"
+                :class="newThoughtRating && star <= newThoughtRating ? 'text-[#96BEE6]' : 'text-[#1e407c]/50'"
+              >
+                &#9733;
+              </button>
+            </div>
+
+            <button
+              @click="submitThought"
+              :disabled="!newThoughtContent.trim() || isSubmitting"
+              class="bg-[#1e407c] hover:bg-[#2a5299] disabled:bg-[#0a2a52] disabled:text-[#4a7aa5]/60 text-white px-4 py-2 rounded-xl text-sm font-medium transition-colors"
+            >
+              {{ isSubmitting ? 'Posting...' : 'Post' }}
+            </button>
+          </div>
+          <p class="text-xs text-[#4a7aa5] text-right">{{ newThoughtContent.length }}/500</p>
+        </div>
+
+        <!-- Thoughts list -->
+        <div v-for="thought in thoughts" :key="thought.id"
+          class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4">
+          <div class="flex items-start justify-between mb-2">
+            <div>
+              <span class="font-medium text-white text-sm">{{ thought.authorDisplayName }}</span>
+              <span class="text-xs text-[#4a7aa5] ml-2">{{ new Date(thought.createdAt).toLocaleDateString() }}</span>
+            </div>
+            <button
+              v-if="thought.authorId === auth.user?.id"
+              @click="deleteThought(thought)"
+              class="text-red-400 text-xs hover:text-red-300"
+            >
+              Delete
+            </button>
+          </div>
+          <div v-if="thought.rating" class="mb-1">
+            <span v-for="star in 5" :key="star"
+              :class="star <= thought.rating ? 'text-[#96BEE6]' : 'text-[#1e407c]/50'">&#9733;</span>
+          </div>
+          <p class="text-sm text-[#96BEE6]/80">{{ thought.content }}</p>
+        </div>
+
+        <div v-if="thoughts.length === 0" class="text-center text-[#5a8ab5] py-4 text-sm">
+          No thoughts yet. Be the first to share one.
+        </div>
+      </section>
+
+      <div v-if="error" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 text-sm mt-4">
+        {{ error }}
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/web/src/views/FriendVenuesView.vue
+++ b/src/web/src/views/FriendVenuesView.vue
@@ -1,0 +1,216 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { friendsApi } from '../services/friends'
+import { thoughtsApi, type Thought, type CreateThoughtRequest } from '../services/thoughts'
+import { useAuthStore } from '../stores/auth'
+import type { Venue } from '../services/venues'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const friendId = computed(() => route.params.friendId as string)
+const venueId = computed(() => route.params.id as string | undefined)
+
+const venues = ref<Venue[]>([])
+const selectedVenue = ref<Venue | null>(null)
+const thoughts = ref<Thought[]>([])
+const isLoading = ref(true)
+const error = ref('')
+
+// Thought composer
+const newThoughtContent = ref('')
+const isSubmitting = ref(false)
+
+const isDetailMode = computed(() => !!venueId.value)
+
+async function load() {
+  isLoading.value = true
+  error.value = ''
+  try {
+    if (isDetailMode.value) {
+      const [venueRes, thoughtsRes] = await Promise.all([
+        friendsApi.getFriendVenue(friendId.value, venueId.value!),
+        thoughtsApi.getForTarget('venue', venueId.value!, friendId.value),
+      ])
+      selectedVenue.value = venueRes.data
+      thoughts.value = thoughtsRes.data
+    } else {
+      const res = await friendsApi.getFriendVenues(friendId.value)
+      venues.value = res.data.items || []
+    }
+  } catch {
+    error.value = 'Failed to load venues'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function submitThought() {
+  if (!newThoughtContent.value.trim() || !venueId.value) return
+  isSubmitting.value = true
+  try {
+    const req: CreateThoughtRequest = {
+      content: newThoughtContent.value.trim(),
+      targetUserId: friendId.value,
+      targetType: 'venue',
+      targetId: venueId.value,
+    }
+    const res = await thoughtsApi.create(req)
+    thoughts.value.unshift(res.data)
+    newThoughtContent.value = ''
+  } catch {
+    error.value = 'Failed to post thought'
+  } finally {
+    isSubmitting.value = false
+  }
+}
+
+async function deleteThought(thought: Thought) {
+  try {
+    await thoughtsApi.remove(thought.id)
+    thoughts.value = thoughts.value.filter(t => t.id !== thought.id)
+  } catch {
+    error.value = 'Failed to delete thought'
+  }
+}
+
+const venueTypeLabel = (type: string) => {
+  const map: Record<string, string> = { bar: 'Bar', lounge: 'Lounge', restaurant: 'Restaurant', other: 'Other' }
+  return map[type] || type
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto">
+    <button @click="router.back()" class="text-[#96BEE6] text-sm mb-4">&larr; Back</button>
+
+    <div v-if="isLoading" class="text-center text-[#5a8ab5] py-12">Loading...</div>
+
+    <div v-else-if="error && !selectedVenue && venues.length === 0"
+      class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 text-sm">
+      {{ error }}
+    </div>
+
+    <!-- Venue list -->
+    <template v-else-if="!isDetailMode">
+      <h2 class="text-xl font-semibold mb-4">Venues</h2>
+
+      <div v-if="venues.length === 0" class="text-center text-[#5a8ab5] py-12">
+        No venues yet
+      </div>
+
+      <div v-else class="space-y-3">
+        <router-link
+          v-for="venue in venues"
+          :key="venue.id"
+          :to="`/friends/${friendId}/venues/${venue.id}`"
+          class="block bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 hover:border-[#1e407c]/50 transition-colors"
+        >
+          <div class="flex items-start gap-3">
+            <img
+              v-if="venue.photoUrls?.length"
+              :src="venue.photoUrls[0]"
+              class="w-12 h-12 object-cover rounded-lg shrink-0"
+            />
+            <div v-else class="w-12 h-12 bg-[#0a2a52] rounded-lg shrink-0 flex items-center justify-center text-xs text-[#96BEE6]/70">
+              {{ venueTypeLabel(venue.type).charAt(0) }}
+            </div>
+            <div class="flex-1 min-w-0">
+              <h3 class="font-medium text-white truncate">{{ venue.name }}</h3>
+              <p class="text-xs text-[#5a8ab5]">{{ venueTypeLabel(venue.type) }}</p>
+              <p v-if="venue.address" class="text-xs text-[#4a7aa5] truncate">{{ venue.address }}</p>
+            </div>
+          </div>
+        </router-link>
+      </div>
+    </template>
+
+    <!-- Venue detail -->
+    <template v-else-if="selectedVenue">
+      <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl overflow-hidden mb-4">
+        <img
+          v-if="selectedVenue.photoUrls?.length"
+          :src="selectedVenue.photoUrls[0]"
+          class="w-full h-48 object-cover"
+        />
+        <div class="p-4 space-y-3">
+          <h2 class="text-xl font-semibold text-white">{{ selectedVenue.name }}</h2>
+          <span class="text-xs px-2 py-0.5 rounded-full bg-[#0a2a52] text-[#96BEE6]">
+            {{ venueTypeLabel(selectedVenue.type) }}
+          </span>
+          <p v-if="selectedVenue.address" class="text-sm text-[#5a8ab5]">{{ selectedVenue.address }}</p>
+          <a v-if="selectedVenue.website" :href="selectedVenue.website" target="_blank"
+            class="text-sm text-[#96BEE6] hover:underline block">
+            {{ selectedVenue.website }}
+          </a>
+          <div v-if="selectedVenue.rating" class="flex items-center gap-1">
+            <span v-for="star in 5" :key="star"
+              :class="star <= selectedVenue.rating ? 'text-[#96BEE6]' : 'text-[#1e407c]/50'">&#9733;</span>
+          </div>
+          <div v-if="selectedVenue.labels?.length" class="flex flex-wrap gap-1">
+            <span v-for="label in selectedVenue.labels" :key="label"
+              class="text-xs px-2 py-0.5 rounded-full bg-[#0a2a52] text-[#96BEE6]">
+              {{ label }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <!-- Thoughts section -->
+      <section class="space-y-4">
+        <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">
+          Thoughts ({{ thoughts.length }})
+        </h3>
+
+        <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 space-y-3">
+          <textarea
+            v-model="newThoughtContent"
+            placeholder="Share your thoughts about this venue..."
+            maxlength="500"
+            rows="3"
+            class="w-full bg-[#0a2a52] border border-[#1e407c]/50 rounded-xl px-4 py-3 text-white placeholder-[#4a7aa5] focus:outline-none focus:border-[#1e407c] resize-none"
+          ></textarea>
+          <div class="flex items-center justify-between">
+            <p class="text-xs text-[#4a7aa5]">{{ newThoughtContent.length }}/500</p>
+            <button
+              @click="submitThought"
+              :disabled="!newThoughtContent.trim() || isSubmitting"
+              class="bg-[#1e407c] hover:bg-[#2a5299] disabled:bg-[#0a2a52] disabled:text-[#4a7aa5]/60 text-white px-4 py-2 rounded-xl text-sm font-medium transition-colors"
+            >
+              {{ isSubmitting ? 'Posting...' : 'Post' }}
+            </button>
+          </div>
+        </div>
+
+        <div v-for="thought in thoughts" :key="thought.id"
+          class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4">
+          <div class="flex items-start justify-between mb-2">
+            <div>
+              <span class="font-medium text-white text-sm">{{ thought.authorDisplayName }}</span>
+              <span class="text-xs text-[#4a7aa5] ml-2">{{ new Date(thought.createdAt).toLocaleDateString() }}</span>
+            </div>
+            <button
+              v-if="thought.authorId === auth.user?.id"
+              @click="deleteThought(thought)"
+              class="text-red-400 text-xs hover:text-red-300"
+            >
+              Delete
+            </button>
+          </div>
+          <p class="text-sm text-[#96BEE6]/80">{{ thought.content }}</p>
+        </div>
+
+        <div v-if="thoughts.length === 0" class="text-center text-[#5a8ab5] py-4 text-sm">
+          No thoughts yet. Be the first to share one.
+        </div>
+      </section>
+
+      <div v-if="error" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 text-sm mt-4">
+        {{ error }}
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/web/src/views/FriendsView.vue
+++ b/src/web/src/views/FriendsView.vue
@@ -174,7 +174,6 @@ onMounted(load)
           <div class="flex items-center justify-between">
             <button @click="router.push(`/friends/${friend.friendId}`)" class="flex-1 text-left">
               <h3 class="font-medium text-white">{{ friend.friendDisplayName }}</h3>
-              <p v-if="friend.friendEmail" class="text-sm text-[#5a8ab5]">{{ friend.friendEmail }}</p>
               <p class="text-xs text-[#4a7aa5] mt-1">Friends since {{ new Date(friend.createdAt).toLocaleDateString() }}</p>
             </button>
             <button @click="removeFriend(friend)" class="text-red-400 text-sm ml-4 hover:text-red-300">Remove</button>
@@ -193,7 +192,6 @@ onMounted(load)
           class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4"
         >
           <h3 class="font-medium text-white mb-1">{{ req.friendDisplayName }}</h3>
-          <p v-if="req.friendEmail" class="text-sm text-[#5a8ab5] mb-3">{{ req.friendEmail }}</p>
           <div class="flex gap-2">
             <button @click="acceptRequest(req)" class="flex-1 bg-[#1e407c] hover:bg-[#2a5299] text-white py-2 rounded-xl text-sm font-medium">
               Accept

--- a/src/web/src/views/FriendsView.vue
+++ b/src/web/src/views/FriendsView.vue
@@ -1,0 +1,226 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { friendsApi, type Friendship, type FriendInvite } from '../services/friends'
+import { notificationsApi } from '../services/notifications'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+const friends = ref<Friendship[]>([])
+const sentRequests = ref<Friendship[]>([])
+const receivedRequests = ref<Friendship[]>([])
+const invite = ref<FriendInvite | null>(null)
+const unreadCount = ref(0)
+const isLoading = ref(true)
+const isCreatingInvite = ref(false)
+const linkCopied = ref(false)
+const error = ref('')
+const activeTab = ref<'friends' | 'requests'>('friends')
+
+const pendingCount = computed(() => receivedRequests.value.length)
+const inviteLink = computed(() => invite.value ? `${window.location.origin}/friends/join/${invite.value.id}` : '')
+
+async function load() {
+  isLoading.value = true
+  error.value = ''
+  try {
+    const [friendsRes, requestsRes, notifRes] = await Promise.all([
+      friendsApi.list(),
+      friendsApi.listRequests(),
+      notificationsApi.list(1),
+    ])
+    friends.value = friendsRes.data
+    sentRequests.value = requestsRes.data.sent
+    receivedRequests.value = requestsRes.data.received
+    unreadCount.value = notifRes.data.unreadCount
+  } catch {
+    error.value = 'Failed to load friends'
+  } finally {
+    isLoading.value = false
+  }
+}
+
+async function createInvite() {
+  isCreatingInvite.value = true
+  try {
+    const res = await friendsApi.createInvite()
+    invite.value = res.data
+  } catch {
+    error.value = 'Failed to create invite'
+  } finally {
+    isCreatingInvite.value = false
+  }
+}
+
+async function copyLink() {
+  if (!inviteLink.value) return
+  await navigator.clipboard.writeText(inviteLink.value)
+  linkCopied.value = true
+  setTimeout(() => { linkCopied.value = false }, 2000)
+}
+
+async function acceptRequest(friendship: Friendship) {
+  try {
+    await friendsApi.accept(friendship.id)
+    receivedRequests.value = receivedRequests.value.filter(r => r.id !== friendship.id)
+    friends.value.push({ ...friendship, status: 'accepted' })
+  } catch {
+    error.value = 'Failed to accept request'
+  }
+}
+
+async function declineRequest(friendship: Friendship) {
+  try {
+    await friendsApi.decline(friendship.id)
+    receivedRequests.value = receivedRequests.value.filter(r => r.id !== friendship.id)
+  } catch {
+    error.value = 'Failed to decline request'
+  }
+}
+
+async function removeFriend(friendship: Friendship) {
+  if (!confirm(`Remove ${friendship.friendDisplayName} from friends?`)) return
+  try {
+    await friendsApi.remove(friendship.id)
+    friends.value = friends.value.filter(f => f.id !== friendship.id)
+  } catch {
+    error.value = 'Failed to remove friend'
+  }
+}
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto">
+    <div class="flex items-center justify-between mb-6">
+      <h2 class="text-xl font-semibold">Friends</h2>
+      <button @click="router.back()" class="text-[#96BEE6] text-sm">Back</button>
+    </div>
+
+    <!-- Tabs -->
+    <div class="flex gap-2 mb-6">
+      <button
+        v-for="tab in (['friends', 'requests'] as const)"
+        :key="tab"
+        @click="activeTab = tab"
+        class="px-4 py-2.5 min-h-[44px] rounded-full text-sm border transition-colors relative"
+        :class="activeTab === tab
+          ? 'bg-[#1e407c] border-[#1e407c] text-white'
+          : 'bg-[#0a2a52] border-[#1e407c]/50 text-[#96BEE6] hover:border-[#1e407c]'"
+      >
+        {{ tab === 'friends' ? `Friends (${friends.length})` : 'Requests' }}
+        <span v-if="tab === 'requests' && pendingCount > 0"
+          class="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full text-xs flex items-center justify-center text-white">
+          {{ pendingCount }}
+        </span>
+      </button>
+    </div>
+
+    <div v-if="error" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 mb-4 text-sm">
+      {{ error }}
+    </div>
+
+    <div v-if="isLoading" class="text-center text-[#5a8ab5] py-12">Loading...</div>
+
+    <!-- Friends tab -->
+    <template v-else-if="activeTab === 'friends'">
+      <!-- Invite section -->
+      <section class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 mb-4 space-y-3">
+        <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">Invite a Friend</h3>
+        <p class="text-sm text-[#5a8ab5]">Generate a link to share with someone you want to add as a friend.</p>
+
+        <div v-if="invite" class="space-y-3">
+          <div class="bg-[#0a2a52] rounded-lg p-3">
+            <p class="text-xs text-[#5a8ab5] mb-1">Invite Code</p>
+            <p class="text-lg font-mono font-bold text-[#96BEE6] tracking-widest">{{ invite.id }}</p>
+          </div>
+
+          <div class="flex gap-2">
+            <button
+              @click="copyLink"
+              class="flex-1 bg-[#1e407c] hover:bg-[#2a5299] text-white py-2.5 rounded-xl text-sm font-medium transition-colors"
+            >
+              {{ linkCopied ? 'Copied' : 'Copy Link' }}
+            </button>
+          </div>
+
+          <p class="text-xs text-[#4a7aa5]">
+            Expires {{ new Date(invite.expiresAt).toLocaleDateString() }}
+          </p>
+        </div>
+
+        <button
+          v-else
+          @click="createInvite"
+          :disabled="isCreatingInvite"
+          class="w-full bg-[#1e407c] hover:bg-[#2a5299] disabled:bg-[#0a2a52] text-white py-3 rounded-xl font-medium transition-colors"
+        >
+          {{ isCreatingInvite ? 'Creating...' : 'Generate Invite Link' }}
+        </button>
+      </section>
+
+      <!-- Friends list -->
+      <div v-if="friends.length === 0" class="text-center text-[#5a8ab5] py-8">
+        <p>No friends yet</p>
+        <p class="text-sm mt-1">Share an invite link to get started</p>
+      </div>
+
+      <div v-else class="space-y-3">
+        <div
+          v-for="friend in friends"
+          :key="friend.id"
+          class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 hover:border-[#1e407c]/50 transition-colors"
+        >
+          <div class="flex items-center justify-between">
+            <button @click="router.push(`/friends/${friend.friendId}`)" class="flex-1 text-left">
+              <h3 class="font-medium text-white">{{ friend.friendDisplayName }}</h3>
+              <p v-if="friend.friendEmail" class="text-sm text-[#5a8ab5]">{{ friend.friendEmail }}</p>
+              <p class="text-xs text-[#4a7aa5] mt-1">Friends since {{ new Date(friend.createdAt).toLocaleDateString() }}</p>
+            </button>
+            <button @click="removeFriend(friend)" class="text-red-400 text-sm ml-4 hover:text-red-300">Remove</button>
+          </div>
+        </div>
+      </div>
+    </template>
+
+    <!-- Requests tab -->
+    <template v-else>
+      <div v-if="receivedRequests.length > 0" class="space-y-3 mb-6">
+        <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">Received</h3>
+        <div
+          v-for="req in receivedRequests"
+          :key="req.id"
+          class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4"
+        >
+          <h3 class="font-medium text-white mb-1">{{ req.friendDisplayName }}</h3>
+          <p v-if="req.friendEmail" class="text-sm text-[#5a8ab5] mb-3">{{ req.friendEmail }}</p>
+          <div class="flex gap-2">
+            <button @click="acceptRequest(req)" class="flex-1 bg-[#1e407c] hover:bg-[#2a5299] text-white py-2 rounded-xl text-sm font-medium">
+              Accept
+            </button>
+            <button @click="declineRequest(req)" class="flex-1 bg-[#0a2a52] hover:bg-[#041e3e] text-[#96BEE6] py-2 rounded-xl text-sm font-medium border border-[#1e407c]/50">
+              Decline
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div v-if="sentRequests.length > 0" class="space-y-3">
+        <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">Sent</h3>
+        <div
+          v-for="req in sentRequests"
+          :key="req.id"
+          class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4"
+        >
+          <h3 class="font-medium text-white">{{ req.friendDisplayName }}</h3>
+          <p class="text-sm text-[#4a7aa5]">Pending</p>
+        </div>
+      </div>
+
+      <div v-if="receivedRequests.length === 0 && sentRequests.length === 0"
+        class="text-center text-[#5a8ab5] py-8">
+        No pending requests
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/web/src/views/ItemDetailView.vue
+++ b/src/web/src/views/ItemDetailView.vue
@@ -4,7 +4,10 @@ import { useRoute, useRouter } from 'vue-router'
 import { useItemsStore } from '../stores/items'
 import { useVenuesStore } from '../stores/venues'
 import { itemsApi, type Item } from '../services/items'
+import { thoughtsApi, type Thought } from '../services/thoughts'
+import { useAuthStore } from '../stores/auth'
 import StarRating from '../components/common/StarRating.vue'
+import ThoughtsList from '../components/common/ThoughtsList.vue'
 import AutocompleteInput from '../components/common/AutocompleteInput.vue'
 import { RefreshKey } from '../composables/refreshKey'
 
@@ -29,6 +32,11 @@ const editVenueAddress = ref('')
 const editTags = ref<string[]>([])
 const newTag = ref('')
 const newJournalEntry = ref('')
+
+// Friend thoughts
+const auth = useAuthStore()
+const friendThoughts = ref<Thought[]>([])
+const isLoadingThoughts = ref(false)
 
 // Photo management
 const isUploadingPhoto = ref(false)
@@ -150,7 +158,25 @@ registerRefresh?.(refreshItem)
 
 onMounted(async () => {
   await refreshItem()
+  loadThoughts()
 })
+
+async function loadThoughts() {
+  if (!item.value || !auth.user) return
+  isLoadingThoughts.value = true
+  try {
+    const res = await thoughtsApi.getForTarget('item', item.value.id, auth.user.id)
+    friendThoughts.value = res.data
+  } catch { /* silent */ }
+  isLoadingThoughts.value = false
+}
+
+async function handleDeleteThought(thought: Thought) {
+  try {
+    await thoughtsApi.remove(thought.id)
+    friendThoughts.value = friendThoughts.value.filter(t => t.id !== thought.id)
+  } catch { /* silent */ }
+}
 
 function resetEditFields(data: Item) {
   editRating.value = data.userRating ?? 0
@@ -627,6 +653,14 @@ function isAiGenerated(data: Item): boolean {
       <span v-for="tag in item.tags" :key="tag" class="text-xs bg-[#0a2a52] text-[#96BEE6] px-2 py-1 rounded-full">
         {{ tag }}
       </span>
+    </div>
+
+    <!-- Friend Thoughts -->
+    <div v-if="!isEditing && friendThoughts.length > 0" class="mt-6">
+      <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide mb-3">
+        Friend Thoughts ({{ friendThoughts.length }})
+      </h3>
+      <ThoughtsList :thoughts="friendThoughts" @delete="handleDeleteThought" />
     </div>
 
     <!-- Delete Confirmation Modal -->

--- a/src/web/src/views/JoinFriendView.vue
+++ b/src/web/src/views/JoinFriendView.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { ref, onMounted, computed } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { friendsApi } from '../services/friends'
+import { useAuthStore } from '../stores/auth'
+
+const route = useRoute()
+const router = useRouter()
+const auth = useAuthStore()
+const code = computed(() => (route.params.code as string).toUpperCase())
+const isJoining = ref(false)
+const isLoading = ref(true)
+const success = ref(false)
+const friendName = ref('')
+const error = ref('')
+
+async function join() {
+  isJoining.value = true
+  error.value = ''
+  try {
+    const res = await friendsApi.joinViaInvite(code.value)
+    friendName.value = res.data.friendDisplayName
+    success.value = true
+  } catch (e: any) {
+    error.value = e.response?.data?.error || 'Failed to join. The invite may be expired or invalid.'
+  } finally {
+    isJoining.value = false
+  }
+}
+
+onMounted(() => {
+  isLoading.value = false
+  if (!auth.isAuthenticated) {
+    // They'll be redirected to login; after login they'll come back here
+    return
+  }
+})
+</script>
+
+<template>
+  <div class="p-4 max-w-lg mx-auto flex flex-col items-center justify-center min-h-[60vh]">
+    <template v-if="success">
+      <div class="text-center space-y-4">
+        <div class="w-16 h-16 bg-[#1e407c] rounded-full flex items-center justify-center mx-auto">
+          <svg class="w-8 h-8 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+          </svg>
+        </div>
+        <h2 class="text-xl font-semibold text-white">You are now friends with {{ friendName }}</h2>
+        <p class="text-[#5a8ab5]">You can now view each other's collections and share thoughts.</p>
+        <button
+          @click="router.push('/friends')"
+          class="bg-[#1e407c] hover:bg-[#2a5299] text-white px-6 py-3 rounded-xl font-medium transition-colors"
+        >
+          View Friends
+        </button>
+      </div>
+    </template>
+
+    <template v-else>
+      <div class="text-center space-y-6">
+        <h2 class="text-xl font-semibold text-white">Friend Invite</h2>
+        <div class="bg-[#041e3e] border border-[#0a2a52] rounded-xl p-6 space-y-4">
+          <p class="text-[#96BEE6]">You've been invited to connect as friends.</p>
+          <div class="bg-[#0a2a52] rounded-lg p-3">
+            <p class="text-xs text-[#5a8ab5] mb-1">Invite Code</p>
+            <p class="text-lg font-mono font-bold text-[#96BEE6] tracking-widest">{{ code }}</p>
+          </div>
+
+          <div v-if="error" class="bg-red-900/30 border border-red-700 text-red-300 rounded-xl p-3 text-sm">
+            {{ error }}
+          </div>
+
+          <button
+            @click="join"
+            :disabled="isJoining"
+            class="w-full bg-[#1e407c] hover:bg-[#2a5299] disabled:bg-[#0a2a52] text-white py-3 rounded-xl font-medium transition-colors"
+          >
+            {{ isJoining ? 'Joining...' : 'Accept Invite' }}
+          </button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>

--- a/src/web/src/views/ProfileView.vue
+++ b/src/web/src/views/ProfileView.vue
@@ -400,6 +400,20 @@ async function changePassword() {
         </button>
       </section>
 
+      <!-- Friends -->
+      <router-link
+        to="/friends"
+        class="block bg-[#041e3e] border border-[#0a2a52] rounded-xl p-4 hover:border-[#1e407c]/50 transition-colors"
+      >
+        <div class="flex items-center justify-between">
+          <div>
+            <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide">Friends</h3>
+            <p class="text-sm text-[#5a8ab5] mt-1">View friends, invites, and shared collections</p>
+          </div>
+          <span class="text-[#96BEE6]">&rarr;</span>
+        </div>
+      </router-link>
+
       <!-- Admin link -->
       <router-link
         v-if="auth.isAdmin"

--- a/src/web/src/views/VenueDetailView.vue
+++ b/src/web/src/views/VenueDetailView.vue
@@ -3,11 +3,15 @@ import { ref, inject, onMounted, computed } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { venuesApi, type Venue } from '../services/venues'
 import { itemsApi, type Item } from '../services/items'
+import { thoughtsApi, type Thought } from '../services/thoughts'
+import { useAuthStore } from '../stores/auth'
 import { RefreshKey } from '../composables/refreshKey'
 import StarRating from '../components/common/StarRating.vue'
+import ThoughtsList from '../components/common/ThoughtsList.vue'
 
 const route = useRoute()
 const router = useRouter()
+const auth = useAuthStore()
 const registerRefresh = inject(RefreshKey)
 
 const venue = ref<Venue | null>(null)
@@ -15,6 +19,8 @@ const linkedItems = ref<Item[]>([])
 const isEditing = ref(false)
 const isDeleting = ref(false)
 const isSaving = ref(false)
+const friendThoughts = ref<Thought[]>([])
+const isLoadingThoughts = ref(false)
 
 const editName = ref('')
 const editAddress = ref('')
@@ -64,7 +70,27 @@ async function refreshVenue() {
 
 registerRefresh?.(refreshVenue)
 
-onMounted(refreshVenue)
+onMounted(async () => {
+  await refreshVenue()
+  loadThoughts()
+})
+
+async function loadThoughts() {
+  if (!venue.value || !auth.user) return
+  isLoadingThoughts.value = true
+  try {
+    const res = await thoughtsApi.getForTarget('venue', venue.value.id, auth.user.id)
+    friendThoughts.value = res.data
+  } catch { /* silent */ }
+  isLoadingThoughts.value = false
+}
+
+async function handleDeleteThought(thought: Thought) {
+  try {
+    await thoughtsApi.remove(thought.id)
+    friendThoughts.value = friendThoughts.value.filter(t => t.id !== thought.id)
+  } catch { /* silent */ }
+}
 
 function resetEditFields(data: Venue) {
   editName.value = data.name
@@ -374,6 +400,14 @@ const photoUrls = computed(() => venue.value?.photoUrls ?? [])
         </div>
       </div>
     </template>
+
+    <!-- Friend Thoughts (read-only mode only) -->
+    <div v-if="!isEditing && friendThoughts.length > 0" class="mt-6">
+      <h3 class="text-sm font-medium text-[#96BEE6] uppercase tracking-wide mb-3">
+        Friend Thoughts ({{ friendThoughts.length }})
+      </h3>
+      <ThoughtsList :thoughts="friendThoughts" @delete="handleDeleteThought" />
+    </div>
 
     <!-- Edit mode -->
     <template v-else>

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/FriendsControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/FriendsControllerTests.cs
@@ -1,0 +1,207 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class FriendsControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public FriendsControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ListFriends_ReturnsAcceptedFriends()
+    {
+        var friends = new List<Friendship>
+        {
+            new() { Id = "f1", UserId = CustomWebApplicationFactory.TestUserId, FriendId = "friend-1", FriendDisplayName = "Alice", Status = FriendshipStatus.Accepted }
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            100,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((friends, (string?)null));
+
+        var response = await _client.GetAsync("/api/friends");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<List<Friendship>>();
+        body.Should().HaveCount(1);
+        body![0].FriendDisplayName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task ListRequests_ReturnsSentAndReceived()
+    {
+        var requests = new List<Friendship>
+        {
+            new() { Id = "f1", UserId = CustomWebApplicationFactory.TestUserId, FriendId = "u2", Status = FriendshipStatus.PendingSent },
+            new() { Id = "f2", UserId = CustomWebApplicationFactory.TestUserId, FriendId = "u3", Status = FriendshipStatus.PendingReceived },
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            100,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((requests, (string?)null));
+
+        var response = await _client.GetAsync("/api/friends/requests");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task CreateInvite_ReturnsInviteWithCode()
+    {
+        _factory.CosmosDb.CreateAsync(
+            "friend-invites",
+            Arg.Any<FriendInvite>(),
+            Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<FriendInvite>(1));
+
+        var response = await _client.PostAsync("/api/friends/invite", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<FriendInvite>();
+        body.Should().NotBeNull();
+        body!.Id.Should().HaveLength(8);
+        body.UserId.Should().Be(CustomWebApplicationFactory.TestUserId);
+    }
+
+    [Fact]
+    public async Task JoinViaInvite_WithOwnInvite_ReturnsBadRequest()
+    {
+        var invite = new FriendInvite
+        {
+            Id = "TESTCODE",
+            UserId = CustomWebApplicationFactory.TestUserId,
+            IsActive = true,
+            ExpiresAt = DateTime.UtcNow.AddDays(7)
+        };
+
+        _factory.CosmosDb.GetAsync<FriendInvite>("friend-invites", "TESTCODE", "TESTCODE")
+            .Returns(invite);
+
+        var response = await _client.PostAsync("/api/friends/join/TESTCODE", null);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task JoinViaInvite_WithExpiredInvite_ReturnsNotFound()
+    {
+        var invite = new FriendInvite
+        {
+            Id = "EXPIRED1",
+            UserId = "other-user",
+            IsActive = true,
+            ExpiresAt = DateTime.UtcNow.AddDays(-1)
+        };
+
+        _factory.CosmosDb.GetAsync<FriendInvite>("friend-invites", "EXPIRED1", "EXPIRED1")
+            .Returns(invite);
+
+        var response = await _client.PostAsync("/api/friends/join/EXPIRED1", null);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task RemoveFriend_WithValidFriendship_ReturnsNoContent()
+    {
+        var friendship = new Friendship
+        {
+            Id = "fs-1",
+            UserId = CustomWebApplicationFactory.TestUserId,
+            FriendId = "friend-1",
+            Status = FriendshipStatus.Accepted
+        };
+
+        _factory.CosmosDb.GetAsync<Friendship>("friendships", "fs-1", CustomWebApplicationFactory.TestUserId)
+            .Returns(friendship);
+
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            "friend-1",
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship>(), (string?)null));
+
+        var response = await _client.DeleteAsync("/api/friends/fs-1");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task RemoveFriend_NotOwner_ReturnsNotFound()
+    {
+        _factory.CosmosDb.GetAsync<Friendship>("friendships", "fs-other", CustomWebApplicationFactory.TestUserId)
+            .Returns((Friendship?)null);
+
+        var response = await _client.DeleteAsync("/api/friends/fs-other");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetFriendItems_NotFriends_ReturnsForbid()
+    {
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship>(), (string?)null));
+
+        var response = await _client.GetAsync("/api/friends/stranger-id/items");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task GetFriendItems_AreFriends_ReturnsItems()
+    {
+        var friendship = new Friendship
+        {
+            Id = "fs-1",
+            UserId = CustomWebApplicationFactory.TestUserId,
+            FriendId = "friend-1",
+            Status = FriendshipStatus.Accepted
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship> { friendship }, (string?)null));
+
+        var items = new List<Item>
+        {
+            new() { Id = "item-1", Name = "Test Whiskey", UserId = "friend-1" }
+        };
+
+        _factory.CosmosDb.QueryAsync<Item>(
+            "items",
+            "friend-1",
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Item, bool>>?>())
+            .Returns((items, (string?)null));
+
+        var response = await _client.GetAsync("/api/friends/friend-1/items");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/NotificationsControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/NotificationsControllerTests.cs
@@ -1,0 +1,121 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class NotificationsControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public NotificationsControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ListNotifications_ReturnsNotificationsWithUnreadCount()
+    {
+        var notifications = new List<Notification>
+        {
+            new() { Id = "n1", UserId = CustomWebApplicationFactory.TestUserId, Title = "New friend!", IsRead = false, CreatedAt = DateTime.UtcNow },
+            new() { Id = "n2", UserId = CustomWebApplicationFactory.TestUserId, Title = "New thought", IsRead = true, CreatedAt = DateTime.UtcNow.AddMinutes(-5) },
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "notifications",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            50,
+            Arg.Any<Expression<Func<Notification, bool>>?>())
+            .Returns((notifications, (string?)null));
+
+        var response = await _client.GetAsync("/api/notifications");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MarkRead_ValidNotification_ReturnsOk()
+    {
+        var notification = new Notification
+        {
+            Id = "n1",
+            UserId = CustomWebApplicationFactory.TestUserId,
+            Title = "Test",
+            IsRead = false
+        };
+
+        _factory.CosmosDb.GetAsync<Notification>("notifications", "n1", CustomWebApplicationFactory.TestUserId)
+            .Returns(notification);
+
+        _factory.CosmosDb.UpsertAsync(
+            "notifications",
+            Arg.Any<Notification>(),
+            Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Notification>(1));
+
+        var response = await _client.PutAsync("/api/notifications/n1/read", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task MarkRead_NotFound_ReturnsNotFound()
+    {
+        _factory.CosmosDb.GetAsync<Notification>("notifications", "nonexistent", CustomWebApplicationFactory.TestUserId)
+            .Returns((Notification?)null);
+
+        var response = await _client.PutAsync("/api/notifications/nonexistent/read", null);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task MarkRead_OtherUsersNotification_ReturnsNotFound()
+    {
+        var notification = new Notification
+        {
+            Id = "n-other",
+            UserId = "other-user",
+            Title = "Not mine",
+            IsRead = false
+        };
+
+        _factory.CosmosDb.GetAsync<Notification>("notifications", "n-other", CustomWebApplicationFactory.TestUserId)
+            .Returns(notification);
+
+        var response = await _client.PutAsync("/api/notifications/n-other/read", null);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task MarkAllRead_UpdatesUnreadNotifications()
+    {
+        var unread = new List<Notification>
+        {
+            new() { Id = "n1", UserId = CustomWebApplicationFactory.TestUserId, Title = "A", IsRead = false },
+            new() { Id = "n2", UserId = CustomWebApplicationFactory.TestUserId, Title = "B", IsRead = false },
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "notifications",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            200,
+            Arg.Any<Expression<Func<Notification, bool>>?>())
+            .Returns((unread, (string?)null));
+
+        _factory.CosmosDb.UpsertAsync(
+            "notifications",
+            Arg.Any<Notification>(),
+            Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Notification>(1));
+
+        var response = await _client.PutAsync("/api/notifications/read-all", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/ThoughtsControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/ThoughtsControllerTests.cs
@@ -1,0 +1,202 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Controllers;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class ThoughtsControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+
+    public ThoughtsControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetThoughts_InvalidTargetType_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/api/thoughts/invalid/some-id?targetUserId=user-1");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetThoughts_MissingTargetUserId_ReturnsBadRequest()
+    {
+        var response = await _client.GetAsync("/api/thoughts/item/some-id");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetThoughts_OwnItems_ReturnsOk()
+    {
+        var thoughts = new List<Thought>
+        {
+            new() { Id = "t1", AuthorId = "friend-1", TargetUserId = CustomWebApplicationFactory.TestUserId, TargetType = "item", TargetId = "item-1", Content = "Great!" }
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "thoughts",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            100,
+            Arg.Any<Expression<Func<Thought, bool>>?>())
+            .Returns((thoughts, (string?)null));
+
+        var response = await _client.GetAsync($"/api/thoughts/item/item-1?targetUserId={CustomWebApplicationFactory.TestUserId}");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetThoughts_NotFriendOrOwner_ReturnsForbid()
+    {
+        // Not the owner and not friends
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship>(), (string?)null));
+
+        var response = await _client.GetAsync("/api/thoughts/item/item-1?targetUserId=stranger");
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateThought_OnOwnItem_ReturnsBadRequest()
+    {
+        var request = new CreateThoughtRequest
+        {
+            Content = "Nice!",
+            TargetUserId = CustomWebApplicationFactory.TestUserId,
+            TargetType = "item",
+            TargetId = "item-1"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/thoughts", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateThought_NotFriends_ReturnsForbid()
+    {
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship>(), (string?)null));
+
+        var request = new CreateThoughtRequest
+        {
+            Content = "Nice!",
+            TargetUserId = "stranger",
+            TargetType = "item",
+            TargetId = "item-1"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/thoughts", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task CreateThought_AsFriend_ReturnsOk()
+    {
+        var friendship = new Friendship
+        {
+            UserId = CustomWebApplicationFactory.TestUserId,
+            FriendId = "friend-1",
+            Status = FriendshipStatus.Accepted
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "friendships",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            1,
+            Arg.Any<Expression<Func<Friendship, bool>>?>())
+            .Returns((new List<Friendship> { friendship }, (string?)null));
+
+        _factory.CosmosDb.GetAsync<Item>("items", "item-1", "friend-1")
+            .Returns(new Item { Id = "item-1", Name = "Test Item", UserId = "friend-1" });
+
+        _factory.CosmosDb.CreateAsync(
+            "thoughts",
+            Arg.Any<Thought>(),
+            Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Thought>(1));
+
+        var request = new CreateThoughtRequest
+        {
+            Content = "This is great!",
+            TargetUserId = "friend-1",
+            TargetType = "item",
+            TargetId = "item-1"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/thoughts", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task DeleteThought_NotAuthor_ReturnsNotFound()
+    {
+        _factory.CosmosDb.QueryCrossPartitionAsync<Thought>(
+            "thoughts",
+            Arg.Any<string>(),
+            Arg.Any<IDictionary<string, object>>(),
+            1)
+            .Returns(new List<Thought>());
+
+        var response = await _client.DeleteAsync("/api/thoughts/nonexistent-id");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetMyThoughts_ReturnsThoughts()
+    {
+        var thoughts = new List<Thought>
+        {
+            new() { Id = "t1", AuthorId = CustomWebApplicationFactory.TestUserId, Content = "Loved it!" }
+        };
+
+        _factory.CosmosDb.QueryCrossPartitionAsync<Thought>(
+            "thoughts",
+            Arg.Any<string>(),
+            Arg.Any<IDictionary<string, object>>(),
+            100)
+            .Returns(thoughts);
+
+        var response = await _client.GetAsync("/api/thoughts/mine");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task GetThoughtsOnMyItems_ReturnsThoughts()
+    {
+        var thoughts = new List<Thought>
+        {
+            new() { Id = "t1", AuthorId = "friend-1", TargetUserId = CustomWebApplicationFactory.TestUserId, Content = "Nice!" }
+        };
+
+        _factory.CosmosDb.QueryAsync(
+            "thoughts",
+            CustomWebApplicationFactory.TestUserId,
+            Arg.Any<string?>(),
+            100,
+            Arg.Any<Expression<Func<Thought, bool>>?>())
+            .Returns((thoughts, (string?)null));
+
+        var response = await _client.GetAsync("/api/thoughts/on-my-items");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/CustomWebApplicationFactory.cs
+++ b/tests/WhiskeyAndSmokes.Tests/CustomWebApplicationFactory.cs
@@ -23,6 +23,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
     public IAuthService AuthService { get; } = Substitute.For<IAuthService>();
     public IPromptService PromptService { get; } = Substitute.For<IPromptService>();
     public IAgentService AgentService { get; } = Substitute.For<IAgentService>();
+    public INotificationService NotificationService { get; } = Substitute.For<INotificationService>();
 
     public const string TestUserId = "test-user-id";
     public const string TestUserEmail = "test@example.com";
@@ -62,6 +63,7 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
             ReplaceService<IAuthService>(services, AuthService);
             ReplaceService<IPromptService>(services, PromptService);
             ReplaceService<IAgentService>(services, AgentService);
+            ReplaceService<INotificationService>(services, NotificationService);
 
             // Ensure bounded channel is available
             var channelDescriptor = services.FirstOrDefault(d => d.ServiceType == typeof(Channel<Capture>));
@@ -94,7 +96,10 @@ public class CustomWebApplicationFactory : WebApplicationFactory<Program>
                 options.DefaultAuthenticateScheme = "TestScheme";
                 options.DefaultChallengeScheme = "TestScheme";
                 options.DefaultScheme = "TestScheme";
-            }).AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("TestScheme", null);
+            })
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("TestScheme", null)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("MultiAuth", null)
+            .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("ApiKey", null);
 
             services.AddAuthorizationBuilder()
                 .AddPolicy("AdminOnly", policy =>


### PR DESCRIPTION
Summary

Adds a complete Friends social feature to Drinks & Desserts, enabling users to connect via invite links, browse each other's
collections and venues, and leave thoughts (comments + ratings) on items.

What's New

Friends System

 - Invite-based discovery — shareable 8-char invite codes (cryptographic RNG, 7-day expiry, single-use)
 - Instant friendship — clicking an invite link auto-accepts (inviter pre-approved by sharing)
 - Dual-document pattern — each friendship stored as 2 CosmosDB documents (one per user partition) for efficient per-user queries
 - Full lifecycle — invite, join, accept, decline, remove with both-side cleanup
 - Browse friend data — view friend's collection items and venues with friendship validation on every endpoint

Thoughts (Comments + Ratings)

 - Leave thoughts on a friend's items or venues (500 char limit, optional 1-5 star rating)
 - View friend thoughts on your own items/venues (read-only section on detail views)
 - Edit/delete your own thoughts; whitespace-only content rejected

Notifications

 - In-app notification bell with unread badge and dropdown (auto-refreshes every 60s)
 - Notifications for: friend accepted, new thought left
 - Mark individual or all as read; server-side limit clamped to 1-200

Security & Documentation

 - Cryptographic RNG for invite codes (replaced Random.Shared)
 - Friend email removed from UI (PII reduction)
 - Friendship validation (IDOR protection) on all cross-user endpoints
 - README updated: rebrand, API reference tables, CosmosDB layout, architecture docs

Architecture

4 New CosmosDB Containers

┌──────────────────┬───────────────┬──────────────────────────────────────────┐
│ Container        │ Partition Key │ Purpose                                  │
├──────────────────┼───────────────┼──────────────────────────────────────────┤
│ friendships      │ userId        │ Dual-doc friendship records              │
├──────────────────┼───────────────┼──────────────────────────────────────────┤
│ friend-invites   │ invite code   │ Direct code lookup                       │
├──────────────────┼───────────────┼──────────────────────────────────────────┤
│ thoughts         │ targetUserId  │ Efficient "thoughts on my stuff" queries │
├──────────────────┼───────────────┼──────────────────────────────────────────┤
│ notifications    │ userId        │ Per-user notification feed               │
└──────────────────┴───────────────┴──────────────────────────────────────────┘

Backend — 3 new controllers, 20 endpoints

 - FriendsController — invite, join, accept, decline, remove, browse items/venues
 - ThoughtsController — CRUD + mine + on-my-items
 - NotificationsController — list, mark read, mark all read

Frontend — 5 views, 3 components, 3 services, 6 routes

Testing

 - 24 new tests (9 Friends, 9 Thoughts, 5 Notifications, + TypeScript strict)
 - All 55 tests passing (31 existing + 24 new)
 - vue-tsc -b clean

Files Changed

30 files changed, +2,801 / -23 lines