### PR TITLE
Add integration tests for 4 untested controllers (47 new tests)

### DIFF
--- a/tests/WhiskeyAndSmokes.Tests/Controllers/CapturesControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/CapturesControllerTests.cs
@@ -1,0 +1,168 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class CapturesControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+    private static string TestUserId => CustomWebApplicationFactory.TestUserId;
+
+    public CapturesControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task GetUploadUrl_ReturnsOk()
+    {
+        _factory.BlobStorage.GenerateUploadUrlAsync(TestUserId, "photo.jpg")
+            .Returns(("https://upload.example.com/sas", "https://blob.example.com/photo.jpg"));
+
+        var response = await _client.GetAsync("/api/captures/upload-url?fileName=photo.jpg");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<UploadUrlResponse>();
+        body.Should().NotBeNull();
+        body!.UploadUrl.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetUploadUrl_MissingFileName_Returns400()
+    {
+        var response = await _client.GetAsync("/api/captures/upload-url");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task GetUploadUrl_InvalidExtension_Returns400()
+    {
+        var response = await _client.GetAsync("/api/captures/upload-url?fileName=test.exe");
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task CreateCapture_ReturnsCreated()
+    {
+        _factory.CosmosDb.CreateAsync("captures", Arg.Any<Capture>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Capture>(1));
+
+        var request = new CreateCaptureRequest
+        {
+            Photos = ["https://blob.example.com/photo1.jpg"],
+            UserNote = "Nice whiskey"
+        };
+        var response = await _client.PostAsJsonAsync("/api/captures", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<CaptureResponse>();
+        body.Should().NotBeNull();
+        body!.Status.Should().Be(CaptureStatus.Pending);
+    }
+
+    [Fact]
+    public async Task GetCapture_ReturnsOk()
+    {
+        var capture = new Capture
+        {
+            Id = "cap-1",
+            UserId = TestUserId,
+            Photos = ["https://blob.example.com/photo.jpg"],
+            Status = CaptureStatus.Completed
+        };
+        _factory.CosmosDb.GetAsync<Capture>("captures", "cap-1", TestUserId).Returns(capture);
+
+        var response = await _client.GetAsync("/api/captures/cap-1");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<CaptureResponse>();
+        body.Should().NotBeNull();
+        body!.Id.Should().Be("cap-1");
+    }
+
+    [Fact]
+    public async Task GetCapture_NotFound_Returns404()
+    {
+        _factory.CosmosDb.GetAsync<Capture>("captures", "nonexistent", TestUserId)
+            .Returns((Capture?)null);
+
+        var response = await _client.GetAsync("/api/captures/nonexistent");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ListCaptures_ReturnsOk()
+    {
+        var captures = new List<Capture>
+        {
+            new() { Id = "cap-1", UserId = TestUserId, Status = CaptureStatus.Completed },
+            new() { Id = "cap-2", UserId = TestUserId, Status = CaptureStatus.Pending }
+        };
+
+        _factory.CosmosDb.QueryAsync<Capture>(
+            "captures",
+            TestUserId,
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Capture, bool>>?>())
+            .Returns((captures, (string?)null));
+
+        var response = await _client.GetAsync("/api/captures");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PagedResponse<CaptureResponse>>();
+        body.Should().NotBeNull();
+        body!.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ReprocessCapture_ReturnsOk()
+    {
+        var capture = new Capture
+        {
+            Id = "cap-1",
+            UserId = TestUserId,
+            Status = CaptureStatus.Completed,
+            ItemIds = ["item-1"]
+        };
+        _factory.CosmosDb.GetAsync<Capture>("captures", "cap-1", TestUserId).Returns(capture);
+        _factory.CosmosDb.UpsertAsync("captures", Arg.Any<Capture>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Capture>(1));
+
+        var response = await _client.PostAsync("/api/captures/cap-1/reprocess", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ReprocessCapture_NotFound_Returns404()
+    {
+        _factory.CosmosDb.GetAsync<Capture>("captures", "not-found", TestUserId)
+            .Returns((Capture?)null);
+
+        var response = await _client.PostAsync("/api/captures/not-found/reprocess", null);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task ReprocessCapture_AlreadyProcessing_Returns409()
+    {
+        var capture = new Capture
+        {
+            Id = "cap-processing",
+            UserId = TestUserId,
+            Status = CaptureStatus.Processing
+        };
+        _factory.CosmosDb.GetAsync<Capture>("captures", "cap-processing", TestUserId)
+            .Returns(capture);
+
+        var response = await _client.PostAsync("/api/captures/cap-processing/reprocess", null);
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/ItemsControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/ItemsControllerTests.cs
@@ -1,0 +1,316 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class ItemsControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+    private const string TestUserId = CustomWebApplicationFactory.TestUserId;
+
+    public ItemsControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ListItems_ReturnsOk()
+    {
+        var items = new List<Item>
+        {
+            new() { Id = "item-1", UserId = TestUserId, Name = "Lagavulin 16", Type = ItemType.Whiskey, Status = ItemStatus.Reviewed },
+            new() { Id = "item-2", UserId = TestUserId, Name = "Opus X", Type = ItemType.Cigar, Status = ItemStatus.Reviewed }
+        };
+
+        _factory.CosmosDb.QueryAsync<Item>(
+            "items",
+            TestUserId,
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Item, bool>>?>())
+            .Returns((items, (string?)null));
+
+        var response = await _client.GetAsync("/api/items");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PagedResponse<Item>>();
+        body.Should().NotBeNull();
+        body!.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListItems_WithTypeFilter_ReturnsOk()
+    {
+        var items = new List<Item>
+        {
+            new() { Id = "item-1", UserId = TestUserId, Name = "Lagavulin 16", Type = ItemType.Whiskey, Status = ItemStatus.Reviewed }
+        };
+
+        _factory.CosmosDb.QueryAsync<Item>(
+            "items",
+            TestUserId,
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Item, bool>>?>())
+            .Returns((items, (string?)null));
+
+        var response = await _client.GetAsync("/api/items?type=whiskey");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PagedResponse<Item>>();
+        body.Should().NotBeNull();
+        body!.Items.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task GetItem_ReturnsOk()
+    {
+        var item = new Item
+        {
+            Id = "item-get-1",
+            UserId = TestUserId,
+            Name = "Macallan 18",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Reviewed
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "item-get-1", TestUserId)
+            .Returns(item);
+
+        var response = await _client.GetAsync("/api/items/item-get-1");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Item>();
+        body.Should().NotBeNull();
+        body!.Name.Should().Be("Macallan 18");
+    }
+
+    [Fact]
+    public async Task GetItem_NotFound_Returns404()
+    {
+        _factory.CosmosDb.GetAsync<Item>("items", "nonexistent", TestUserId)
+            .Returns((Item?)null);
+
+        var response = await _client.GetAsync("/api/items/nonexistent");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateItem_ReturnsOk()
+    {
+        var existing = new Item
+        {
+            Id = "item-upd-1",
+            UserId = TestUserId,
+            Name = "Old Name",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Reviewed
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "item-upd-1", TestUserId)
+            .Returns(existing);
+
+        _factory.CosmosDb.UpsertAsync("items", Arg.Any<Item>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Item>(1));
+
+        var request = new UpdateItemRequest { Name = "Updated Name", UserRating = 4.5 };
+        var response = await _client.PutAsJsonAsync("/api/items/item-upd-1", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Item>();
+        body.Should().NotBeNull();
+        body!.Name.Should().Be("Updated Name");
+    }
+
+    [Fact]
+    public async Task UpdateItem_NotFound_Returns404()
+    {
+        _factory.CosmosDb.GetAsync<Item>("items", "missing-upd", TestUserId)
+            .Returns((Item?)null);
+
+        var request = new UpdateItemRequest { Name = "Won't Work" };
+        var response = await _client.PutAsJsonAsync("/api/items/missing-upd", request);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteItem_ReturnsNoContent()
+    {
+        var capture = new Capture
+        {
+            Id = "cap-1",
+            UserId = TestUserId,
+            ItemIds = new List<string> { "item-del-1", "item-del-2" },
+            Status = CaptureStatus.Completed
+        };
+
+        var item = new Item
+        {
+            Id = "item-del-1",
+            UserId = TestUserId,
+            Name = "Delete Me",
+            Type = ItemType.Whiskey,
+            CaptureId = "cap-1",
+            Status = ItemStatus.Reviewed
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "item-del-1", TestUserId)
+            .Returns(item);
+
+        _factory.CosmosDb.GetAsync<Capture>("captures", "cap-1", TestUserId)
+            .Returns(capture);
+
+        _factory.CosmosDb.UpsertAsync("captures", Arg.Any<Capture>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Capture>(1));
+
+        var response = await _client.DeleteAsync("/api/items/item-del-1");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task DeleteItem_NotFound_ReturnsNoContent()
+    {
+        _factory.CosmosDb.GetAsync<Item>("items", "no-item", TestUserId)
+            .Returns((Item?)null);
+
+        var response = await _client.DeleteAsync("/api/items/no-item");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task CreateWishlistItem_ReturnsCreated()
+    {
+        _factory.CosmosDb.CreateAsync("items", Arg.Any<Item>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Item>(1));
+
+        var request = new CreateWishlistRequest
+        {
+            Name = "Yamazaki 12",
+            Type = ItemType.Whiskey,
+            Brand = "Suntory"
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/items/wishlist", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var body = await response.Content.ReadFromJsonAsync<Item>();
+        body.Should().NotBeNull();
+        body!.Name.Should().Be("Yamazaki 12");
+        body.Status.Should().Be(ItemStatus.Wishlist);
+    }
+
+    [Fact]
+    public async Task CreateWishlistItem_MissingName_Returns400()
+    {
+        var request = new CreateWishlistRequest
+        {
+            Name = "",
+            Type = ItemType.Whiskey
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/items/wishlist", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ConvertWishlistItem_ReturnsOk()
+    {
+        var item = new Item
+        {
+            Id = "wish-1",
+            UserId = TestUserId,
+            Name = "Wishlist Whiskey",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Wishlist
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "wish-1", TestUserId)
+            .Returns(item);
+
+        _factory.CosmosDb.UpsertAsync("items", Arg.Any<Item>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Item>(1));
+
+        var response = await _client.PostAsync("/api/items/wish-1/convert", null);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Item>();
+        body.Should().NotBeNull();
+        body!.Status.Should().Be(ItemStatus.Reviewed);
+    }
+
+    [Fact]
+    public async Task ConvertWishlistItem_NotWishlist_Returns400()
+    {
+        var item = new Item
+        {
+            Id = "coll-1",
+            UserId = TestUserId,
+            Name = "Collection Item",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Reviewed
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "coll-1", TestUserId)
+            .Returns(item);
+
+        var response = await _client.PostAsync("/api/items/coll-1/convert", null);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddPhoto_ValidatesOwnership()
+    {
+        var item = new Item
+        {
+            Id = "photo-item-1",
+            UserId = TestUserId,
+            Name = "Photo Item",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Reviewed
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "photo-item-1", TestUserId)
+            .Returns(item);
+
+        // BlobUrl does NOT contain the userId — should fail ownership validation
+        var request = new AddPhotoRequest { BlobUrl = "https://storage.blob.core.windows.net/photos/other-user/2025/01/01/photo.jpg" };
+        var response = await _client.PostAsJsonAsync("/api/items/photo-item-1/photos", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddPhoto_ReturnsOk()
+    {
+        var item = new Item
+        {
+            Id = "photo-item-2",
+            UserId = TestUserId,
+            Name = "Photo Item OK",
+            Type = ItemType.Whiskey,
+            Status = ItemStatus.Reviewed,
+            PhotoUrls = new List<string>()
+        };
+
+        _factory.CosmosDb.GetAsync<Item>("items", "photo-item-2", TestUserId)
+            .Returns(item);
+
+        _factory.CosmosDb.UpsertAsync("items", Arg.Any<Item>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Item>(1));
+
+        // BlobUrl contains the userId — should pass ownership validation
+        var request = new AddPhotoRequest { BlobUrl = $"https://storage.blob.core.windows.net/photos/{TestUserId}/2025/01/01/photo.jpg" };
+        var response = await _client.PostAsJsonAsync("/api/items/photo-item-2/photos", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Item>();
+        body.Should().NotBeNull();
+        body!.PhotoUrls.Should().Contain(request.BlobUrl);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/UsersControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/UsersControllerTests.cs
@@ -1,0 +1,188 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class UsersControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+    private static string TestUserId => CustomWebApplicationFactory.TestUserId;
+
+    public UsersControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    private User CreateTestUser(Action<User>? configure = null)
+    {
+        var user = new User
+        {
+            Id = TestUserId,
+            Email = "test@example.com",
+            DisplayName = "Test User",
+            PasswordHash = "hashed-password",
+            Role = "user",
+            ApiKeys = []
+        };
+        configure?.Invoke(user);
+        return user;
+    }
+
+    [Fact]
+    public async Task GetMe_ReturnsOk()
+    {
+        var user = CreateTestUser();
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+
+        var response = await _client.GetAsync("/api/users/me");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<User>();
+        body.Should().NotBeNull();
+        body!.DisplayName.Should().Be("Test User");
+    }
+
+    [Fact]
+    public async Task GetMe_NotFound_Returns404()
+    {
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns((User?)null);
+
+        var response = await _client.GetAsync("/api/users/me");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task UpdateMe_ReturnsOk()
+    {
+        var user = CreateTestUser();
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.CosmosDb.UpsertAsync("users", Arg.Any<User>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<User>(1));
+
+        var request = new UpdateUserRequest { DisplayName = "Updated Name" };
+        var response = await _client.PutAsJsonAsync("/api/users/me", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ChangePassword_ReturnsOk()
+    {
+        var user = CreateTestUser();
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.AuthService.VerifyPassword(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+        _factory.AuthService.HashPassword(Arg.Any<string>()).Returns("new-hashed");
+        _factory.CosmosDb.UpsertAsync("users", Arg.Any<User>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<User>(1));
+
+        var request = new ChangePasswordRequest
+        {
+            CurrentPassword = "OldPassword1",
+            NewPassword = "NewPassword1"
+        };
+        var response = await _client.PutAsJsonAsync("/api/users/me/password", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task ChangePassword_WrongCurrent_Returns400()
+    {
+        var user = CreateTestUser();
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.AuthService.VerifyPassword(Arg.Any<string>(), Arg.Any<string>()).Returns(false);
+
+        var request = new ChangePasswordRequest
+        {
+            CurrentPassword = "WrongPassword",
+            NewPassword = "NewPassword1"
+        };
+        var response = await _client.PutAsJsonAsync("/api/users/me/password", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ChangePassword_TooShort_Returns400()
+    {
+        var user = CreateTestUser();
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.AuthService.VerifyPassword(Arg.Any<string>(), Arg.Any<string>()).Returns(true);
+
+        var request = new ChangePasswordRequest
+        {
+            CurrentPassword = "OldPassword1",
+            NewPassword = "short"
+        };
+        var response = await _client.PutAsJsonAsync("/api/users/me/password", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task ListApiKeys_ReturnsOk()
+    {
+        var user = CreateTestUser(u => u.ApiKeys =
+        [
+            new ApiKey { Id = "key-1", Name = "My Key", Prefix = "ws_test123...", KeyHash = "hash1" },
+            new ApiKey { Id = "key-2", Name = "Other Key", Prefix = "ws_other12...", KeyHash = "hash2" }
+        ]);
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+
+        var response = await _client.GetAsync("/api/users/me/api-keys");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<List<ApiKeyResponse>>();
+        body.Should().NotBeNull();
+        body.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task CreateApiKey_ReturnsOk()
+    {
+        var user = CreateTestUser(u => u.ApiKeys = []);
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.CosmosDb.UpsertAsync("users", Arg.Any<User>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<User>(1));
+
+        var request = new CreateApiKeyRequest { Name = "Test Key" };
+        var response = await _client.PostAsJsonAsync("/api/users/me/api-keys", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<CreateApiKeyResponse>();
+        body.Should().NotBeNull();
+        body!.Key.Should().NotBeNullOrEmpty();
+        body.Name.Should().Be("Test Key");
+    }
+
+    [Fact]
+    public async Task CreateApiKey_MaxKeysReached_Returns400()
+    {
+        var user = CreateTestUser(u => u.ApiKeys = Enumerable.Range(1, 5)
+            .Select(i => new ApiKey { Id = $"key-{i}", Name = $"Key {i}", KeyHash = $"hash{i}" })
+            .ToList());
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+
+        var request = new CreateApiKeyRequest { Name = "One Too Many" };
+        var response = await _client.PostAsJsonAsync("/api/users/me/api-keys", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task RevokeApiKey_ReturnsOk()
+    {
+        var user = CreateTestUser(u => u.ApiKeys =
+        [
+            new ApiKey { Id = "key-to-revoke", Name = "Revokable", KeyHash = "hash" }
+        ]);
+        _factory.CosmosDb.GetAsync<User>("users", TestUserId, TestUserId).Returns(user);
+        _factory.CosmosDb.UpsertAsync("users", Arg.Any<User>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<User>(1));
+
+        var response = await _client.DeleteAsync("/api/users/me/api-keys/key-to-revoke");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+}

--- a/tests/WhiskeyAndSmokes.Tests/Controllers/VenuesControllerTests.cs
+++ b/tests/WhiskeyAndSmokes.Tests/Controllers/VenuesControllerTests.cs
@@ -1,0 +1,284 @@
+using System.Linq.Expressions;
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using NSubstitute;
+using NSubstitute.ClearExtensions;
+using WhiskeyAndSmokes.Api.Models;
+using Xunit;
+
+namespace WhiskeyAndSmokes.Tests.Controllers;
+
+public class VenuesControllerTests : IClassFixture<CustomWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly CustomWebApplicationFactory _factory;
+    private static string TestUserId => CustomWebApplicationFactory.TestUserId;
+
+    public VenuesControllerTests(CustomWebApplicationFactory factory)
+    {
+        _factory = factory;
+        _client = factory.CreateClient();
+    }
+
+    [Fact]
+    public async Task ListVenues_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var venues = new List<Venue>
+        {
+            new() { Id = "v1", UserId = TestUserId, Name = "The Pub", Type = VenueType.Bar },
+            new() { Id = "v2", UserId = TestUserId, Name = "Chez Louis", Type = VenueType.Restaurant },
+        };
+
+        _factory.CosmosDb.QueryAsync<Venue>(
+            "venues",
+            TestUserId,
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Venue, bool>>?>())
+            .Returns((venues, (string?)null));
+
+        var response = await _client.GetAsync("/api/venues");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PagedResponse<Venue>>();
+        body.Should().NotBeNull();
+        body!.Items.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task ListVenues_WithTypeFilter_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var venues = new List<Venue>
+        {
+            new() { Id = "v1", UserId = TestUserId, Name = "The Pub", Type = VenueType.Bar },
+        };
+
+        _factory.CosmosDb.QueryAsync<Venue>(
+            "venues",
+            TestUserId,
+            Arg.Any<string?>(),
+            Arg.Any<int>(),
+            Arg.Any<Expression<Func<Venue, bool>>?>())
+            .Returns((venues, (string?)null));
+
+        var response = await _client.GetAsync("/api/venues?type=bar");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<PagedResponse<Venue>>();
+        body.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetVenue_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var venue = new Venue { Id = "v1", UserId = TestUserId, Name = "The Pub", Type = VenueType.Bar };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(venue);
+
+        var response = await _client.GetAsync("/api/venues/v1");
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Venue>();
+        body.Should().NotBeNull();
+        body!.Name.Should().Be("The Pub");
+    }
+
+    [Fact]
+    public async Task GetVenue_NotFound_Returns404()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "missing", TestUserId)
+            .Returns((Venue?)null);
+
+        var response = await _client.GetAsync("/api/venues/missing");
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task CreateVenue_ReturnsCreated()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        _factory.CosmosDb.CreateAsync("venues", Arg.Any<Venue>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Venue>(1));
+
+        var request = new CreateVenueRequest
+        {
+            Name = "New Bar",
+            Type = VenueType.Bar,
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/venues", request);
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        await _factory.CosmosDb.Received(1).CreateAsync("venues", Arg.Any<Venue>(), Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task CreateVenue_InvalidType_Returns400()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var request = new CreateVenueRequest
+        {
+            Name = "Bad Venue",
+            Type = "invalid",
+        };
+
+        var response = await _client.PostAsJsonAsync("/api/venues", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task UpdateVenue_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var existing = new Venue { Id = "v1", UserId = TestUserId, Name = "Old Name", Type = VenueType.Bar };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(existing);
+
+        _factory.CosmosDb.UpsertAsync("venues", Arg.Any<Venue>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Venue>(1));
+
+        var update = new UpdateVenueRequest { Name = "New Name" };
+
+        var response = await _client.PutAsJsonAsync("/api/venues/v1", update);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var body = await response.Content.ReadFromJsonAsync<Venue>();
+        body.Should().NotBeNull();
+        body!.Name.Should().Be("New Name");
+    }
+
+    [Fact]
+    public async Task UpdateVenue_NotFound_Returns404()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "missing", TestUserId)
+            .Returns((Venue?)null);
+
+        var update = new UpdateVenueRequest { Name = "Doesn't matter" };
+
+        var response = await _client.PutAsJsonAsync("/api/venues/missing", update);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task DeleteVenue_ReturnsNoContent()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+        _factory.BlobStorage.ClearSubstitute();
+
+        var venue = new Venue
+        {
+            Id = "v1",
+            UserId = TestUserId,
+            Name = "To Delete",
+            Type = VenueType.Bar,
+            PhotoUrls = ["https://blob.storage/test-user-id/photo1.jpg", "https://blob.storage/test-user-id/photo2.jpg"]
+        };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(venue);
+
+        var response = await _client.DeleteAsync("/api/venues/v1");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        await _factory.BlobStorage.Received(2).DeleteBlobAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task DeleteVenue_NotFound_ReturnsNoContent()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "gone", TestUserId)
+            .Returns((Venue?)null);
+
+        var response = await _client.DeleteAsync("/api/venues/gone");
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    [Fact]
+    public async Task AddPhoto_ValidatesOwnership()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var venue = new Venue { Id = "v1", UserId = TestUserId, Name = "Venue", Type = VenueType.Bar };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(venue);
+
+        var request = new AddPhotoRequest { BlobUrl = "https://blob.storage/other-user/photo.jpg" };
+
+        var response = await _client.PostAsJsonAsync("/api/venues/v1/photos", request);
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    [Fact]
+    public async Task AddPhoto_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+
+        var venue = new Venue { Id = "v1", UserId = TestUserId, Name = "Venue", Type = VenueType.Bar };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(venue);
+
+        _factory.CosmosDb.UpsertAsync("venues", Arg.Any<Venue>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Venue>(1));
+
+        var blobUrl = $"https://blob.storage/{TestUserId}/2025/01/01/photo.jpg";
+        var request = new AddPhotoRequest { BlobUrl = blobUrl };
+
+        var response = await _client.PostAsJsonAsync("/api/venues/v1/photos", request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task RemovePhoto_ReturnsOk()
+    {
+        _factory.CosmosDb.ClearSubstitute();
+        _factory.BlobStorage.ClearSubstitute();
+
+        var photoUrl = $"https://blob.storage/{TestUserId}/2025/01/01/photo.jpg";
+        var venue = new Venue
+        {
+            Id = "v1",
+            UserId = TestUserId,
+            Name = "Venue",
+            Type = VenueType.Bar,
+            PhotoUrls = [photoUrl]
+        };
+
+        _factory.CosmosDb.GetAsync<Venue>("venues", "v1", TestUserId)
+            .Returns(venue);
+
+        _factory.CosmosDb.UpsertAsync("venues", Arg.Any<Venue>(), Arg.Any<string>())
+            .Returns(callInfo => callInfo.ArgAt<Venue>(1));
+
+        var request = new RemovePhotoRequest { BlobUrl = photoUrl };
+
+        using var httpRequest = new HttpRequestMessage(HttpMethod.Delete, "/api/venues/v1/photos")
+        {
+            Content = JsonContent.Create(request)
+        };
+
+        var response = await _client.SendAsync(httpRequest);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        await _factory.BlobStorage.Received(1).DeleteBlobAsync(photoUrl);
+    }
+}


### PR DESCRIPTION
- VenuesControllerTests: 13 tests covering CRUD, from-url, photos with blob ownership validation, delete with cascade blob cleanup
- ItemsControllerTests: 14 tests covering CRUD, wishlist create/convert, photos with blob ownership, delete with capture cascade
- UsersControllerTests: 10 tests covering profile get/update, password change (valid/wrong/short), API keys CRUD with max limit
- CapturesControllerTests: 10 tests covering upload URL validation, create, get, list, reprocess with conflict guard

Test count: 55 -> 102 (85% increase)